### PR TITLE
Add support for explicit FailsafeExecutor compose method

### DIFF
--- a/src/main/java/net/jodah/failsafe/Failsafe.java
+++ b/src/main/java/net/jodah/failsafe/Failsafe.java
@@ -36,7 +36,8 @@ public class Failsafe {
    *   Failsafe.with(fallback, retryPolicy, circuitBreaker).get(supplier);
    * </pre>
    * </p>
-   * This results in the following internal composition when executing the {@code supplier} and handling its result:
+   * This results in the following internal composition when executing a {@code runnable} or {@code supplier} and
+   * handling its result:
    * <p>
    * <pre>
    *   Fallback(RetryPolicy(CircuitBreaker(Supplier)))
@@ -65,10 +66,11 @@ public class Failsafe {
    * the last policy being applied first. For example, consider:
    * <p>
    * <pre>
-   *   Failsafe.with(fallback, retryPolicy, circuitBreaker).get(supplier);
+   *   Failsafe.with(Arrays.asList(fallback, retryPolicy, circuitBreaker)).get(supplier);
    * </pre>
    * </p>
-   * This results in the following internal composition when executing the {@code supplier} and handling its result:
+   * This results in the following internal composition when executing a {@code runnable} or {@code supplier} and
+   * handling its result:
    * <p>
    * <pre>
    *   Fallback(RetryPolicy(CircuitBreaker(Supplier)))

--- a/src/main/java/net/jodah/failsafe/Timeout.java
+++ b/src/main/java/net/jodah/failsafe/Timeout.java
@@ -114,4 +114,9 @@ public class Timeout<R> extends PolicyListeners<Timeout<R>, R> implements Policy
   public PolicyExecutor toExecutor(AbstractExecution execution) {
     return new TimeoutExecutor(this, execution);
   }
+
+  @Override
+  public String toString() {
+    return "Timeout[timeout=" + timeout + ", interruptable=" + interruptable + ']';
+  }
 }

--- a/src/test/java/net/jodah/failsafe/functional/BlockedExecutionTest.java
+++ b/src/test/java/net/jodah/failsafe/functional/BlockedExecutionTest.java
@@ -43,7 +43,7 @@ public class BlockedExecutionTest {
     Timeout<Boolean> timeout = Timeout.of(Duration.ofMillis(100));
     RetryPolicy<Boolean> rp = new RetryPolicy<Boolean>().withDelay(Duration.ofMillis(1000)).handleResult(false);
 
-    Future<Boolean> future = Failsafe.with(timeout, rp).with(executor).getAsync(() -> {
+    Future<Boolean> future = Failsafe.with(timeout).compose(rp).with(executor).getAsync(() -> {
       // Tie up single thread immediately after execution, before the retry is scheduled
       executor.submit(Testing.uncheck(() -> Thread.sleep(1000)));
       return false;
@@ -65,7 +65,7 @@ public class BlockedExecutionTest {
       return true;
     }).handleResult(false);
 
-    Future<Boolean> future = Failsafe.with(timeout, fallback).with(executor).getAsync(() -> {
+    Future<Boolean> future = Failsafe.with(timeout).compose(fallback).with(executor).getAsync(() -> {
       // Tie up single thread immediately after execution, before the fallback is scheduled
       executor.submit(Testing.uncheck(() -> Thread.sleep(1000)));
       return false;

--- a/src/test/java/net/jodah/failsafe/functional/TimeoutTest.java
+++ b/src/test/java/net/jodah/failsafe/functional/TimeoutTest.java
@@ -45,7 +45,7 @@ public class TimeoutTest {
       System.out.println("Retrying");
     });
 
-    Runnable test = () -> testSyncAndAsyncFailure(Failsafe.with(retryPolicy, timeout), () -> {
+    Runnable test = () -> testSyncAndAsyncFailure(Failsafe.with(retryPolicy).compose(timeout), () -> {
       timeoutCounter.set(0);
       retryPolicyCounter.set(0);
     }, () -> {
@@ -85,7 +85,7 @@ public class TimeoutTest {
       System.out.println("Retrying");
     });
 
-    Runnable test = () -> testSyncAndAsyncFailure(Failsafe.with(retryPolicy, timeout), () -> {
+    Runnable test = () -> testSyncAndAsyncFailure(Failsafe.with(retryPolicy).compose(timeout), () -> {
       executionCounter.set(0);
       timeoutSuccessCounter.set(0);
     }, () -> {
@@ -125,7 +125,7 @@ public class TimeoutTest {
       System.out.println("Retrying");
     });
 
-    Runnable test = () -> testSyncAndAsyncFailure(Failsafe.with(timeout, retryPolicy), () -> {
+    Runnable test = () -> testSyncAndAsyncFailure(Failsafe.with(timeout).compose(retryPolicy), () -> {
       executionCounter.set(0);
       timeoutCounter.set(0);
     }, () -> {
@@ -170,7 +170,7 @@ public class TimeoutTest {
       System.out.println("Retrying");
     });
 
-    Runnable test = () -> testSyncAndAsyncFailure(Failsafe.with(timeout, retryPolicy), () -> {
+    Runnable test = () -> testSyncAndAsyncFailure(Failsafe.with(timeout).compose(retryPolicy), () -> {
       executionCounter.set(0);
       timeoutCounter.set(0);
       failedAttemptCounter.set(0);
@@ -211,7 +211,7 @@ public class TimeoutTest {
       throw new IllegalStateException();
     });
 
-    Runnable test = () -> testSyncAndAsyncFailure(Failsafe.with(fallback, timeout), () -> {
+    Runnable test = () -> testSyncAndAsyncFailure(Failsafe.with(fallback).compose(timeout), () -> {
       timeoutCounter.set(0);
       fallbackCounter.set(0);
     }, () -> {
@@ -251,7 +251,7 @@ public class TimeoutTest {
       throw new IllegalStateException();
     });
 
-    Runnable test = () -> testSyncAndAsyncFailure(Failsafe.with(fallback, timeout), () -> {
+    Runnable test = () -> testSyncAndAsyncFailure(Failsafe.with(fallback).compose(timeout), () -> {
       fallbackCounter.set(0);
     }, () -> {
       System.out.println("Executing");
@@ -288,7 +288,7 @@ public class TimeoutTest {
       throw new IllegalStateException();
     });
 
-    Runnable test = () -> testSyncAndAsyncFailure(Failsafe.with(timeout, fallback), () -> {
+    Runnable test = () -> testSyncAndAsyncFailure(Failsafe.with(timeout).compose(fallback), () -> {
       timeoutCounter.set(0);
       fallbackCounter.set(0);
     }, () -> {
@@ -328,7 +328,7 @@ public class TimeoutTest {
       throw new IllegalStateException();
     });
 
-    Runnable test = () -> testSyncAndAsyncFailure(Failsafe.with(timeout, fallback), () -> {
+    Runnable test = () -> testSyncAndAsyncFailure(Failsafe.with(timeout).compose(fallback), () -> {
       timeoutCounter.set(0);
       fallbackCounter.set(0);
     }, () -> {


### PR DESCRIPTION
Adds explicit `FailsafeExecutor.compose` method. Fixes #254.

## Notes

While the new `FailsafeExecutor.compose` method returns a new FailsafeExecutor, the other methods in that class (`with(ExecutorService)`, `onComplete`, etc) do not. So this results in a mix of mutable and immutable methods. 

The existing mutable methods don't seem to be surprising for users, but allowing the new `compose` method to mutate a `FailsafeExecutor` after it's in use could be surprising. Or maybe not? Input welcome.

That said, mutable vs immutable config can be tackled separately when the API is (possibly) re-worked for thread safety.