### PR TITLE
Ratelimiter implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.1
+
+### Improvements
+
+- Issue #308 - Introduce a `RateLimiter` policy.
+
 # 3.0.2
 
 ### Bug Fixes
@@ -16,7 +22,6 @@
 - Issue #215 - Added overflow checking for large user-provided `Duration` values.
 
 # 3.0
-
 
 ### API Changes
 

--- a/src/main/java/dev/failsafe/CircuitBreaker.java
+++ b/src/main/java/dev/failsafe/CircuitBreaker.java
@@ -107,8 +107,8 @@ public interface CircuitBreaker<R> extends Policy<R> {
    * Attempts to acquire a permit for the circuit breaker and throws {@link CircuitBreakerOpenException} if a permit
    * could not be acquired. Permission will be automatically released when a result or failure is recorded.
    *
-   * @throws CircuitBreakerOpenException Thrown when the circuit breaker is in a half-open state and no permits remain
-   * according to the configured success or failure thresholding capacity.
+   * @throws CircuitBreakerOpenException if the circuit breaker is in a half-open state and no permits remain according
+   * to the configured success or failure thresholding capacity.
    * @see #tryAcquirePermit()
    * @see #recordResult(Object)
    * @see #recordFailure(Throwable)

--- a/src/main/java/dev/failsafe/FailsafeExecutor.java
+++ b/src/main/java/dev/failsafe/FailsafeExecutor.java
@@ -107,8 +107,9 @@ public class FailsafeExecutor<R> {
    * @throws NullPointerException if the {@code supplier} is null
    * @throws FailsafeException if the {@code supplier} fails with a checked Exception. {@link
    * FailsafeException#getCause()} can be used to learn the checked exception that caused the failure.
-   * @throws TimeoutExceededException if the execution fails because {@link Timeout} is exceeded.
-   * @throws CircuitBreakerOpenException if the execution fails because {@link CircuitBreaker} is open.
+   * @throws TimeoutExceededException if the execution fails because a {@link Timeout} is exceeded.
+   * @throws CircuitBreakerOpenException if the execution fails because a {@link CircuitBreaker} is open.
+   * @throws RateLimitExceededException if the execution fails because a {@link RateLimiter} is exceeded.
    */
   public <T extends R> T get(CheckedSupplier<T> supplier) {
     return call(toCtxSupplier(supplier));
@@ -120,8 +121,9 @@ public class FailsafeExecutor<R> {
    * @throws NullPointerException if the {@code supplier} is null
    * @throws FailsafeException if the {@code supplier} fails with a checked Exception. {@link
    * FailsafeException#getCause()} can be used to learn the checked exception that caused the failure.
-   * @throws TimeoutExceededException if the execution fails because {@link Timeout} is exceeded.
-   * @throws CircuitBreakerOpenException if the execution fails because {@link CircuitBreaker} is open.
+   * @throws TimeoutExceededException if the execution fails because a {@link Timeout} is exceeded.
+   * @throws CircuitBreakerOpenException if the execution fails because a {@link CircuitBreaker} is open.
+   * @throws RateLimitExceededException if the execution fails because a {@link RateLimiter} is exceeded.
    */
   public <T extends R> T get(ContextualSupplier<T, T> supplier) {
     return call(Assert.notNull(supplier, "supplier"));
@@ -130,14 +132,14 @@ public class FailsafeExecutor<R> {
   /**
    * Executes the {@code supplier} asynchronously until a successful result is returned or the configured policies are
    * exceeded.
-   * <p>
-   * If the execution fails because a {@link Timeout} is exceeded, the resulting future is completed exceptionally with
-   * {@link TimeoutExceededException}.
-   * </p>
-   * <p>
-   * If the execution fails because a {@link CircuitBreaker} is open, the resulting future is completed exceptionally
-   * with {@link CircuitBreakerOpenException}.
-   * </p>
+   * <ul>
+   *   <li>If the execution fails because a {@link Timeout} is exceeded, the resulting future is completed exceptionally
+   *   with {@link TimeoutExceededException}.</li>
+   *   <li>If the execution fails because a {@link CircuitBreaker} is open, the resulting future is completed
+   *   exceptionally with {@link CircuitBreakerOpenException}.</li>
+   *   <li>If the execution fails because a {@link RateLimiter} is exceeded, the resulting future is completed
+   *   exceptionally with {@link RateLimitExceededException}.</li>
+   * </ul>
    *
    * @throws NullPointerException if the {@code supplier} is null
    * @throws RejectedExecutionException if the {@code supplier} cannot be scheduled for execution
@@ -149,14 +151,14 @@ public class FailsafeExecutor<R> {
   /**
    * Executes the {@code supplier} asynchronously until a successful result is returned or the configured policies are
    * exceeded.
-   * <p>
-   * If the execution fails because a {@link Timeout} is exceeded, the resulting future is completed exceptionally with
-   * {@link TimeoutExceededException}.
-   * </p>
-   * <p>
-   * If the execution fails because a {@link CircuitBreaker} is open, the resulting future is completed exceptionally
-   * with {@link CircuitBreakerOpenException}.
-   * </p>
+   * <ul>
+   *   <li>If the execution fails because a {@link Timeout} is exceeded, the resulting future is completed exceptionally
+   *   with {@link TimeoutExceededException}.</li>
+   *   <li>If the execution fails because a {@link CircuitBreaker} is open, the resulting future is completed
+   *   exceptionally with {@link CircuitBreakerOpenException}.</li>
+   *   <li>If the execution fails because a {@link RateLimiter} is exceeded, the resulting future is completed
+   *   exceptionally with {@link RateLimitExceededException}.</li>
+   * </ul>
    *
    * @throws NullPointerException if the {@code supplier} is null
    * @throws RejectedExecutionException if the {@code supplier} cannot be scheduled for execution
@@ -174,14 +176,14 @@ public class FailsafeExecutor<R> {
    * completed. Any exception that is thrown from the {@code runnable} will automatically be recorded via {@code
    * AsyncExecution.recordFailure}.
    * </p>
-   * <p>
-   * If the execution fails because a {@link Timeout} is exceeded, the resulting future is completed exceptionally with
-   * {@link TimeoutExceededException}.
-   * </p>
-   * <p>
-   * If the execution fails because a {@link CircuitBreaker} is open, the resulting future is completed exceptionally
-   * with {@link CircuitBreakerOpenException}.
-   * </p>
+   * <ul>
+   *   <li>If the execution fails because a {@link Timeout} is exceeded, the resulting future is completed exceptionally
+   *   with {@link TimeoutExceededException}.</li>
+   *   <li>If the execution fails because a {@link CircuitBreaker} is open, the resulting future is completed
+   *   exceptionally with {@link CircuitBreakerOpenException}.</li>
+   *   <li>If the execution fails because a {@link RateLimiter} is exceeded, the resulting future is completed
+   *   exceptionally with {@link RateLimitExceededException}.</li>
+   * </ul>
    *
    * @throws NullPointerException if the {@code supplier} is null
    * @throws RejectedExecutionException if the {@code supplier} cannot be scheduled for execution
@@ -195,14 +197,14 @@ public class FailsafeExecutor<R> {
    * policies are exceeded.
    * <p>Cancelling the resulting {@link CompletableFuture} will automatically cancels the supplied {@link
    * CompletionStage} if it's a {@link Future}.</p>
-   * <p>
-   * If the execution fails because a {@link Timeout} is exceeded, the resulting future is completed exceptionally with
-   * {@link TimeoutExceededException}.
-   * </p>
-   * <p>
-   * If the execution fails because a {@link CircuitBreaker} is open, the resulting future is completed exceptionally
-   * with {@link CircuitBreakerOpenException}.
-   * </p>
+   * <ul>
+   *   <li>If the execution fails because a {@link Timeout} is exceeded, the resulting future is completed exceptionally
+   *   with {@link TimeoutExceededException}.</li>
+   *   <li>If the execution fails because a {@link CircuitBreaker} is open, the resulting future is completed
+   *   exceptionally with {@link CircuitBreakerOpenException}.</li>
+   *   <li>If the execution fails because a {@link RateLimiter} is exceeded, the resulting future is completed
+   *   exceptionally with {@link RateLimitExceededException}.</li>
+   * </ul>
    *
    * @throws NullPointerException if the {@code supplier} is null
    * @throws RejectedExecutionException if the {@code supplier} cannot be scheduled for execution
@@ -216,14 +218,14 @@ public class FailsafeExecutor<R> {
    * policies are exceeded.
    * <p>Cancelling the resulting {@link CompletableFuture} will automatically cancels the supplied {@link
    * CompletionStage} if it's a {@link Future}.</p>
-   * <p>
-   * If the execution fails because a {@link Timeout} is exceeded, the resulting future is completed exceptionally with
-   * {@link TimeoutExceededException}.
-   * </p>
-   * <p>
-   * If the execution fails because a {@link CircuitBreaker} is open, the resulting future is completed exceptionally
-   * with {@link CircuitBreakerOpenException}.
-   * </p>
+   * <ul>
+   *   <li>If the execution fails because a {@link Timeout} is exceeded, the resulting future is completed exceptionally
+   *   with {@link TimeoutExceededException}.</li>
+   *   <li>If the execution fails because a {@link CircuitBreaker} is open, the resulting future is completed
+   *   exceptionally with {@link CircuitBreakerOpenException}.</li>
+   *   <li>If the execution fails because a {@link RateLimiter} is exceeded, the resulting future is completed
+   *   exceptionally with {@link RateLimitExceededException}.</li>
+   * </ul>
    *
    * @throws NullPointerException if the {@code supplier} is null
    * @throws RejectedExecutionException if the {@code supplier} cannot be scheduled for execution
@@ -239,8 +241,9 @@ public class FailsafeExecutor<R> {
    * @throws NullPointerException if the {@code runnable} is null
    * @throws FailsafeException if the {@code runnable} fails with a checked Exception. {@link
    * FailsafeException#getCause()} can be used to learn the checked exception that caused the failure.
-   * @throws TimeoutExceededException if the execution fails because {@link Timeout} is exceeded.
-   * @throws CircuitBreakerOpenException if the execution fails because {@link CircuitBreaker} is open.
+   * @throws TimeoutExceededException if the execution fails because a {@link Timeout} is exceeded.
+   * @throws CircuitBreakerOpenException if the execution fails because a {@link CircuitBreaker} is open.
+   * @throws RateLimitExceededException if the execution fails because a {@link RateLimiter} is exceeded.
    */
   public void run(CheckedRunnable runnable) {
     call(toCtxSupplier(runnable));
@@ -252,8 +255,9 @@ public class FailsafeExecutor<R> {
    * @throws NullPointerException if the {@code runnable} is null
    * @throws FailsafeException if the {@code runnable} fails with a checked Exception. {@link
    * FailsafeException#getCause()} can be used to learn the checked exception that caused the failure.
-   * @throws TimeoutExceededException if the execution fails because {@link Timeout} is exceeded.
-   * @throws CircuitBreakerOpenException if the execution fails because {@link CircuitBreaker} is open.
+   * @throws TimeoutExceededException if the execution fails because a {@link Timeout} is exceeded.
+   * @throws CircuitBreakerOpenException if the execution fails because a {@link CircuitBreaker} is open.
+   * @throws RateLimitExceededException if the execution fails because a {@link RateLimiter} is exceeded.
    */
   public void run(ContextualRunnable<Void> runnable) {
     call(toCtxSupplier(runnable));
@@ -261,14 +265,14 @@ public class FailsafeExecutor<R> {
 
   /**
    * Executes the {@code runnable} asynchronously until successful or until the configured policies are exceeded.
-   * <p>
-   * If the execution fails because a {@link Timeout} is exceeded, the resulting future is completed exceptionally with
-   * {@link TimeoutExceededException}.
-   * </p>
-   * <p>
-   * If the execution fails because a {@link CircuitBreaker} is open, the resulting future is completed exceptionally
-   * with {@link CircuitBreakerOpenException}.
-   * </p>
+   * <ul>
+   *   <li>If the execution fails because a {@link Timeout} is exceeded, the resulting future is completed exceptionally
+   *   with {@link TimeoutExceededException}.</li>
+   *   <li>If the execution fails because a {@link CircuitBreaker} is open, the resulting future is completed
+   *   exceptionally with {@link CircuitBreakerOpenException}.</li>
+   *   <li>If the execution fails because a {@link RateLimiter} is exceeded, the resulting future is completed
+   *   exceptionally with {@link RateLimitExceededException}.</li>
+   * </ul>
    *
    * @throws NullPointerException if the {@code runnable} is null
    * @throws RejectedExecutionException if the {@code runnable} cannot be scheduled for execution
@@ -279,14 +283,14 @@ public class FailsafeExecutor<R> {
 
   /**
    * Executes the {@code runnable} asynchronously until successful or until the configured policies are exceeded.
-   * <p>
-   * If the execution fails because a {@link Timeout} is exceeded, the resulting future is completed exceptionally with
-   * {@link TimeoutExceededException}.
-   * </p>
-   * <p>
-   * If the execution fails because a {@link CircuitBreaker} is open, the resulting future is completed exceptionally
-   * with {@link CircuitBreakerOpenException}.
-   * </p>
+   * <ul>
+   *   <li>If the execution fails because a {@link Timeout} is exceeded, the resulting future is completed exceptionally
+   *   with {@link TimeoutExceededException}.</li>
+   *   <li>If the execution fails because a {@link CircuitBreaker} is open, the resulting future is completed
+   *   exceptionally with {@link CircuitBreakerOpenException}.</li>
+   *   <li>If the execution fails because a {@link RateLimiter} is exceeded, the resulting future is completed
+   *   exceptionally with {@link RateLimitExceededException}.</li>
+   * </ul>
    *
    * @throws NullPointerException if the {@code runnable} is null
    * @throws RejectedExecutionException if the {@code runnable} cannot be scheduled for execution
@@ -304,14 +308,14 @@ public class FailsafeExecutor<R> {
    * completed. Any exception that is thrown from the {@code runnable} will automatically be recorded via {@code
    * AsyncExecution.recordFailure}.
    * </p>
-   * <p>
-   * If the execution fails because a {@link Timeout} is exceeded, the resulting future is completed exceptionally with
-   * {@link TimeoutExceededException}.
-   * </p>
-   * <p>
-   * If the execution fails because a {@link CircuitBreaker} is open, the resulting future is completed exceptionally
-   * with {@link CircuitBreakerOpenException}.
-   * </p>
+   * <ul>
+   *   <li>If the execution fails because a {@link Timeout} is exceeded, the resulting future is completed exceptionally
+   *   with {@link TimeoutExceededException}.</li>
+   *   <li>If the execution fails because a {@link CircuitBreaker} is open, the resulting future is completed
+   *   exceptionally with {@link CircuitBreakerOpenException}.</li>
+   *   <li>If the execution fails because a {@link RateLimiter} is exceeded, the resulting future is completed
+   *   exceptionally with {@link RateLimitExceededException}.</li>
+   * </ul>
    *
    * @throws NullPointerException if the {@code runnable} is null
    * @throws RejectedExecutionException if the {@code runnable} cannot be scheduled for execution
@@ -423,8 +427,9 @@ public class FailsafeExecutor<R> {
    *
    * @throws FailsafeException if the {@code innerSupplier} fails with a checked Exception or if interrupted while
    * waiting to perform a retry.
-   * @throws TimeoutExceededException if the execution fails because {@link Timeout} is exceeded.
-   * @throws CircuitBreakerOpenException if the execution fails because {@link CircuitBreaker} is open.
+   * @throws TimeoutExceededException if the execution fails because a {@link Timeout} is exceeded.
+   * @throws CircuitBreakerOpenException if the execution fails because a {@link CircuitBreaker} is open.
+   * @throws RateLimitExceededException if the execution fails because a {@link RateLimiter} is exceeded.
    */
   @SuppressWarnings({ "unchecked", "rawtypes" })
   private <T> T call(ContextualSupplier<T, T> innerSupplier) {
@@ -444,14 +449,14 @@ public class FailsafeExecutor<R> {
   /**
    * Calls the asynchronous {@code innerFn} via the configured Scheduler, handling results according to the configured
    * policies.
-   * <p>
-   * If the execution fails because a {@link Timeout} is exceeded, the resulting future is completed exceptionally with
-   * {@link TimeoutExceededException}.
-   * </p>
-   * <p>
-   * If the execution fails because a {@link CircuitBreaker} is open, the resulting future is completed exceptionally
-   * with {@link CircuitBreakerOpenException}.
-   * </p>
+   * <ul>
+   *   <li>If the execution fails because a {@link Timeout} is exceeded, the resulting future is completed exceptionally
+   *   with {@link TimeoutExceededException}.</li>
+   *   <li>If the execution fails because a {@link CircuitBreaker} is open, the resulting future is completed
+   *   exceptionally with {@link CircuitBreakerOpenException}.</li>
+   *   <li>If the execution fails because a {@link RateLimiter} is exceeded, the resulting future is completed
+   *   exceptionally with {@link RateLimitExceededException}.</li>
+   * </ul>
    *
    * @param asyncExecution whether this is a detached, async execution that must be manually completed
    * @throws NullPointerException if the {@code innerFn} is null

--- a/src/main/java/dev/failsafe/Functions.java
+++ b/src/main/java/dev/failsafe/Functions.java
@@ -54,11 +54,11 @@ final class Functions {
       synchronized (execution.getInitial()) {
         execution.setInterruptable(false);
         if (execution.isInterrupted()) {
-          // Clear interrupt flag if interruption was intended
+          // Clear interrupt flag if interruption was performed by Failsafe
           Thread.interrupted();
           return execution.getResult();
         } else if (throwable instanceof InterruptedException)
-          // Set interrupt flag if interrupt occurred but was not intended
+          // Set interrupt flag if interruption was not performed by Failsafe
           Thread.currentThread().interrupt();
       }
 

--- a/src/main/java/dev/failsafe/RateLimitExceededException.java
+++ b/src/main/java/dev/failsafe/RateLimitExceededException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,18 +16,21 @@
 package dev.failsafe;
 
 /**
- * Thrown when a synchronous Failsafe execution fails with an {@link Exception}, wrapping the underlying exception. Use
- * {@link Throwable#getCause()} to learn the cause of the failure.
+ * Thrown when an execution exceeds or would exceed a {@link RateLimiter}.
  *
  * @author Jonathan Halterman
  */
-public class FailsafeException extends RuntimeException {
+public class RateLimitExceededException extends FailsafeException {
   private static final long serialVersionUID = 1L;
 
-  public FailsafeException() {
+  private final RateLimiter<?> rateLimiter;
+
+  public RateLimitExceededException(RateLimiter<?> rateLimiter) {
+    this.rateLimiter = rateLimiter;
   }
 
-  public FailsafeException(Throwable t) {
-    super(t);
+  /** Returns the {@link RateLimiter} that caused the exception. */
+  public RateLimiter<?> getRateLimiter() {
+    return rateLimiter;
   }
 }

--- a/src/main/java/dev/failsafe/RateLimiter.java
+++ b/src/main/java/dev/failsafe/RateLimiter.java
@@ -60,11 +60,12 @@ import java.time.Duration;
 public interface RateLimiter<R> extends Policy<R> {
   /**
    * Returns a smooth {@link RateLimiterBuilder} for the {@code executionRate}, which controls how frequently an
-   * execution is permitted. For example, a executionRate of {@code Duration.ofMillis(10)} would allow one execution
-   * every 10 milliseconds.
+   * execution is permitted. For example, an {@code executionRate} of {@code Duration.ofMillis(10)} would allow one
+   * execution every 10 milliseconds.
    * <p>
-   * Executions are permitted with a delay between executions equal to the {@code executionRate}. If too many executions
-   * are being requested, the delay may be greater.
+   * Executions are performed with no delay until they exceed the {@code executionRate}, after which executions are
+   * either rejected, or if a {@link RateLimiterBuilder#withTimeout(Duration) timeout is configured}, will block until
+   * execution is permitted or the timeout is exceeded.
    *
    * @param executionRate at which executions should be permitted
    */
@@ -79,7 +80,7 @@ public interface RateLimiter<R> extends Policy<R> {
    * <p>
    * Executions are performed with no delay up until the {@code maxExecutions} are reached for the current period, after
    * which executions are either rejected, or if a {@link RateLimiterBuilder#withTimeout(Duration) timeout is
-   * configured}, they will block until a permit is free or the timeout is exceeded.
+   * configured}, will block until execution is permitted or the timeout is exceeded.
    *
    * @param maxExecutions The max number of permitted executions per {@code period}
    * @param period The period after which permitted executions are reset to the {@code maxExecutions}

--- a/src/main/java/dev/failsafe/RateLimiter.java
+++ b/src/main/java/dev/failsafe/RateLimiter.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package dev.failsafe;
+
+import java.time.Duration;
+
+/**
+ * A rate limiter allows you to control the rate of executions as a way of preventing system overload.
+ * <p>
+ * There are two types of rate limiting: <i>smooth</i> and <i>bursty</i>. <i>Smooth</i> rate limiting will evenly spread
+ * out execution requests over-time, effectively smoothing out uneven execution request rates. <i>Bursty</i> rate
+ * limiting allows potential bursts of executions to occur, up to a configured max per time period.</p>
+ * <p>Rate limiting is based on permits, which can be requested in order to perform rate limited execution.
+ * Permits are automatically refreshed over time based on the rate limiter's configuration.</p>
+ * <p>
+ * This class provides methods that block while waiting for permits to become available, and also methods that return
+ * immediately. The blocking methods include:
+ * <ul>
+ *   <li>{@link #acquirePermit()}</li>
+ *   <li>{@link #acquirePermits(int)}</li>
+ *   <li>{@link #acquirePermit(Duration)}</li>
+ *   <li>{@link #acquirePermits(int, Duration)}</li>
+ *   <li>{@link #tryAcquirePermit(Duration)}</li>
+ *   <li>{@link #tryAcquirePermits(int, Duration)}</li>
+ * </ul>
+ * The methods that return immediately include:
+ * <ul>
+ *   <li>{@link #tryAcquirePermit()}</li>
+ *   <li>{@link #tryAcquirePermits(int)}</li>
+ * </ul>
+ * </p>
+ * <p>
+ * This class also provides methods that throw {@link RateLimitExceededException} when permits cannot be acquired, and
+ * also methods that return a boolean. The {@code acquire} methods all throw {@link RateLimitExceededException} when
+ * permits cannot be acquired, and the {@code tryAcquire} methods return a boolean.
+ * </p>
+ * <p>
+ * This class is threadsafe.
+ * </p>
+ *
+ * @param <R> result type
+ * @author Jonathan Halterman
+ * @see RateLimiterConfig
+ * @see RateLimiterBuilder
+ * @see RateLimitExceededException
+ */
+public interface RateLimiter<R> extends Policy<R> {
+  /**
+   * Returns a smooth {@link RateLimiterBuilder} for the {@code executionRate}, which controls how frequently an
+   * execution is permitted. For example, a executionRate of {@code Duration.ofMillis(10)} would allow one execution
+   * every 10 milliseconds.
+   * <p>
+   * Executions are permitted with a delay between executions equal to the {@code executionRate}. If too many executions
+   * are being requested, the delay may be greater.
+   *
+   * @param executionRate at which executions should be permitted
+   */
+  static <R> RateLimiterBuilder<R> builder(Duration executionRate) {
+    return new RateLimiterBuilder<>(executionRate);
+  }
+
+  /**
+   * Returns a bursty {@link RateLimiterBuilder} for the {@code maxExecutions} per {@code period}. For example, a {@code
+   * maxExecutions} value of {@code 100} with a {@code period} of {@code Duration.ofSeconds(1)} would allow up to 100
+   * executions every 1 second.
+   * <p>
+   * Executions are performed with no delay up until the {@code maxExecutions} are reached for the current period, after
+   * which executions are either rejected, or if a {@link RateLimiterBuilder#withTimeout(Duration) timeout is
+   * configured}, they will block until a permit is free or the timeout is exceeded.
+   *
+   * @param maxExecutions The max number of permitted executions per {@code period}
+   * @param period The period after which permitted executions are reset to the {@code maxExecutions}
+   */
+  static <R> RateLimiterBuilder<R> builder(long maxExecutions, Duration period) {
+    return new RateLimiterBuilder<>(maxExecutions, period);
+  }
+
+  /**
+   * Creates a new RateLimiterBuilder that will be based on the {@code config}.
+   */
+  static <R> RateLimiterBuilder<R> builder(RateLimiterConfig<R> config) {
+    return new RateLimiterBuilder<>(config);
+  }
+
+  /**
+   * Returns the {@link RateLimiterConfig} that the RateLimiter was built with.
+   */
+  @Override
+  RateLimiterConfig<R> getConfig();
+
+  /**
+   * Attempts to acquire a permit to perform an execution against the rate limiter, waiting until one is available or
+   * the thread is interrupted.
+   *
+   * @throws InterruptedException if the current thread is interrupted while waiting to acquire a permit
+   * @see #tryAcquirePermit()
+   */
+  default void acquirePermit() throws InterruptedException {
+    acquirePermits(1);
+  }
+
+  /**
+   * Attempts to acquire the requested {@code permits} to perform executions against the rate limiter, waiting until
+   * they are available or the thread is interrupted.
+   *
+   * @throws IllegalArgumentException if {@code permits} is < 1
+   * @throws InterruptedException if the current thread is interrupted while waiting to acquire the {@code permits}
+   * @see #tryAcquirePermits(int)
+   */
+  void acquirePermits(int permits) throws InterruptedException;
+
+  /**
+   * Attempts to acquire a permit to perform an execution against the rate limiter, waiting up to the {@code time
+   * timeout} until one is available, else throwing {@link RateLimitExceededException} if a permit will not be available
+   * in time.
+   *
+   * @throws NullPointerException if {@code timeout} is null
+   * @throws RateLimitExceededException if the rate limiter cannot acquire a permit before the {@code timeout} sicne it
+   * is exceeded
+   * @throws InterruptedException if the current thread is interrupted while waiting to acquire a permit
+   * @see #tryAcquirePermit(Duration)
+   */
+  default void acquirePermit(Duration timeout) throws InterruptedException {
+    acquirePermits(1, timeout);
+  }
+
+  /**
+   * Attempts to acquire the requested {@code permits} to perform executions against the rate limiter, waiting up to the
+   * {@code time timeout} until they are available, else throwing {@link RateLimitExceededException} if the permits will
+   * not be available in time.
+   *
+   * @throws IllegalArgumentException if {@code permits} is < 1
+   * @throws NullPointerException if {@code timeout} is null
+   * @throws RateLimitExceededException if the rate limiter cannot acquire the {@code permits} before the {@code
+   * timeout} sicne it is exceeded
+   * @throws InterruptedException if the current thread is interrupted while waiting to acquire the {@code permits}
+   * @see #tryAcquirePermits(int, Duration)
+   */
+  default void acquirePermits(int permits, Duration timeout) throws InterruptedException {
+    if (!tryAcquirePermits(permits, timeout))
+      throw new RateLimitExceededException(this);
+  }
+
+  /**
+   * Returns whether the rate limiter is smooth.
+   *
+   * @see #builder(Duration)
+   */
+  default boolean isSmooth() {
+    return getConfig().getExecutionRate() != null;
+  }
+
+  /**
+   * Returns whether the rate limiter is bursty.
+   *
+   * @see #builder(long, Duration)
+   */
+  default boolean isBursty() {
+    return getConfig().getPeriod() != null;
+  }
+
+  /**
+   * Tries to acquire a permit to perform an execution against the rate limiter, returning immediately without waiting.
+   *
+   * @return whether the requested {@code permits} are successfully acquired or not
+   */
+  default boolean tryAcquirePermit() {
+    return tryAcquirePermits(1);
+  }
+
+  /**
+   * Tries to acquire the requested {@code permits} to perform executions against the rate limiter, returning
+   * immediately without waiting.
+   *
+   * @return whether the requested {@code permits} are successfully acquired or not
+   * @throws IllegalArgumentException if {@code permits} is < 1
+   */
+  boolean tryAcquirePermits(int permits);
+
+  /**
+   * Tries to acquire a permit to perform an execution against the rate limiter, waiting up to the {@code timeout} until
+   * they are available.
+   *
+   * @return whether a permit is successfully acquired
+   * @throws NullPointerException if {@code timeout} is null
+   * @throws InterruptedException if the current thread is interrupted while waiting to acquire a permit
+   */
+  default boolean tryAcquirePermit(Duration timeout) throws InterruptedException {
+    return tryAcquirePermits(1, timeout);
+  }
+
+  /**
+   * Tries to acquire the requested {@code permits} to perform executions against the rate limiter, waiting up to the
+   * {@code timeout} until they are available.
+   *
+   * @return whether the requested {@code permits} are successfully acquired or not
+   * @throws IllegalArgumentException if {@code permits} is < 1
+   * @throws NullPointerException if {@code timeout} is null
+   * @throws InterruptedException if the current thread is interrupted while waiting to acquire the {@code permits}
+   */
+  boolean tryAcquirePermits(int permits, Duration timeout) throws InterruptedException;
+}

--- a/src/main/java/dev/failsafe/RateLimiterBuilder.java
+++ b/src/main/java/dev/failsafe/RateLimiterBuilder.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package dev.failsafe;
+
+import dev.failsafe.internal.RateLimiterImpl;
+
+import java.time.Duration;
+
+/**
+ * Builds {@link RateLimiter} instances.
+ * <p>
+ * This class is <i>not</i> threadsafe.
+ * </p>
+ *
+ * @param <R> result type
+ * @author Jonathan Halterman
+ * @see RateLimiterConfig
+ * @see RateLimitExceededException
+ */
+public class RateLimiterBuilder<R> extends PolicyBuilder<RateLimiterBuilder<R>, RateLimiterConfig<R>, R> {
+  RateLimiterBuilder(Duration executionRate) {
+    super(new RateLimiterConfig<>(executionRate));
+  }
+
+  RateLimiterBuilder(long maxPermits, Duration period) {
+    super(new RateLimiterConfig<>(maxPermits, period));
+  }
+
+  RateLimiterBuilder(RateLimiterConfig<R> config) {
+    super(new RateLimiterConfig<>(config));
+  }
+
+  /**
+   * Builds a new {@link RateLimiter} using the builder's configuration.
+   */
+  public RateLimiter<R> build() {
+    return new RateLimiterImpl<>(new RateLimiterConfig<>(config));
+  }
+
+  /**
+   * Configures the {@code timeout} to wait for permits to be available. If permits cannot be acquired before the {@code
+   * timeout} is exceeded, then the rate limiter will throw {@link RateLimitExceededException}.
+   */
+  public RateLimiterBuilder<R> withTimeout(Duration timeout) {
+    config.timeout = timeout;
+    return this;
+  }
+}

--- a/src/main/java/dev/failsafe/RateLimiterBuilder.java
+++ b/src/main/java/dev/failsafe/RateLimiterBuilder.java
@@ -16,8 +16,10 @@
 package dev.failsafe;
 
 import dev.failsafe.internal.RateLimiterImpl;
+import dev.failsafe.internal.util.Assert;
 
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 
 /**
  * Builds {@link RateLimiter} instances.
@@ -33,10 +35,12 @@ import java.time.Duration;
 public class RateLimiterBuilder<R> extends PolicyBuilder<RateLimiterBuilder<R>, RateLimiterConfig<R>, R> {
   RateLimiterBuilder(Duration executionRate) {
     super(new RateLimiterConfig<>(executionRate));
+    config.maxWaitTime = Duration.ZERO;
   }
 
   RateLimiterBuilder(long maxPermits, Duration period) {
     super(new RateLimiterConfig<>(maxPermits, period));
+    config.maxWaitTime = Duration.ZERO;
   }
 
   RateLimiterBuilder(RateLimiterConfig<R> config) {
@@ -53,9 +57,11 @@ public class RateLimiterBuilder<R> extends PolicyBuilder<RateLimiterBuilder<R>, 
   /**
    * Configures the {@code maxWaitTime} to wait for permits to be available. If permits cannot be acquired before the
    * {@code maxWaitTime} is exceeded, then the rate limiter will throw {@link RateLimitExceededException}.
+   *
+   * @throws NullPointerException if {@code maxWaitTime} is null
    */
   public RateLimiterBuilder<R> withMaxWaitTime(Duration maxWaitTime) {
-    config.maxWaitTime = maxWaitTime;
+    config.maxWaitTime = Assert.notNull(maxWaitTime, "maxWaitTime");
     return this;
   }
 }

--- a/src/main/java/dev/failsafe/RateLimiterBuilder.java
+++ b/src/main/java/dev/failsafe/RateLimiterBuilder.java
@@ -51,11 +51,11 @@ public class RateLimiterBuilder<R> extends PolicyBuilder<RateLimiterBuilder<R>, 
   }
 
   /**
-   * Configures the {@code timeout} to wait for permits to be available. If permits cannot be acquired before the {@code
-   * timeout} is exceeded, then the rate limiter will throw {@link RateLimitExceededException}.
+   * Configures the {@code maxWaitTime} to wait for permits to be available. If permits cannot be acquired before the
+   * {@code maxWaitTime} is exceeded, then the rate limiter will throw {@link RateLimitExceededException}.
    */
-  public RateLimiterBuilder<R> withTimeout(Duration timeout) {
-    config.timeout = timeout;
+  public RateLimiterBuilder<R> withMaxWaitTime(Duration maxWaitTime) {
+    config.maxWaitTime = maxWaitTime;
     return this;
   }
 }

--- a/src/main/java/dev/failsafe/RateLimiterConfig.java
+++ b/src/main/java/dev/failsafe/RateLimiterConfig.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package dev.failsafe;
+
+import java.time.Duration;
+
+public class RateLimiterConfig<R> extends PolicyConfig<R> {
+  // Smoothing
+  Duration executionRate;
+
+  // Bursting
+  long maxPermits;
+  Duration period;
+
+  // Common
+  Duration timeout;
+
+  RateLimiterConfig(Duration executionRate) {
+    this.executionRate = executionRate;
+  }
+
+  RateLimiterConfig(long maxPermits, Duration period) {
+    this.maxPermits = maxPermits;
+    this.period = period;
+  }
+
+  RateLimiterConfig(RateLimiterConfig<R> config) {
+    super(config);
+    executionRate = config.executionRate;
+    maxPermits = config.maxPermits;
+    period = config.period;
+    timeout = config.timeout;
+  }
+
+  /**
+   * For smooth rate limiters, returns the rate at which executions are permitted, else {@code null} if the rate limiter
+   * is not smooth.
+   *
+   * @see RateLimiter#builder(Duration)
+   */
+  public Duration getExecutionRate() {
+    return executionRate;
+  }
+
+  /**
+   * For bursty rate limiters, returns the max permitted executions per {@link #getPeriod() period}, else {@code null}
+   * if the rate limiter is not bursty.
+   *
+   * @see RateLimiter#builder(long, Duration)
+   */
+  public long getMaxPermits() {
+    return maxPermits;
+  }
+
+  /**
+   * For bursty rate limiters, returns the period after which permits are reset to {@link #getMaxPermits() maxPermits},
+   * else {@code null} if the rate limiter is not bursty.
+   *
+   * @see RateLimiter#builder(long, Duration)
+   */
+  public Duration getPeriod() {
+    return period;
+  }
+
+  /**
+   * Returns the timeout to wait for permits to be available. If permits cannot be acquired before the timeout is
+   * exceeded, then the rate limiter will throw {@link RateLimitExceededException}.
+   *
+   * @see RateLimiterBuilder#withTimeout(Duration)
+   */
+  public Duration getTimeout() {
+    return timeout;
+  }
+}

--- a/src/main/java/dev/failsafe/RateLimiterConfig.java
+++ b/src/main/java/dev/failsafe/RateLimiterConfig.java
@@ -26,7 +26,7 @@ public class RateLimiterConfig<R> extends PolicyConfig<R> {
   Duration period;
 
   // Common
-  Duration timeout;
+  Duration maxWaitTime;
 
   RateLimiterConfig(Duration executionRate) {
     this.executionRate = executionRate;
@@ -42,7 +42,7 @@ public class RateLimiterConfig<R> extends PolicyConfig<R> {
     executionRate = config.executionRate;
     maxPermits = config.maxPermits;
     period = config.period;
-    timeout = config.timeout;
+    maxWaitTime = config.maxWaitTime;
   }
 
   /**
@@ -76,12 +76,12 @@ public class RateLimiterConfig<R> extends PolicyConfig<R> {
   }
 
   /**
-   * Returns the timeout to wait for permits to be available. If permits cannot be acquired before the timeout is
+   * Returns the max time to wait for permits to be available. If permits cannot be acquired before the max wait time is
    * exceeded, then the rate limiter will throw {@link RateLimitExceededException}.
    *
-   * @see RateLimiterBuilder#withTimeout(Duration)
+   * @see RateLimiterBuilder#withMaxWaitTime(Duration)
    */
-  public Duration getTimeout() {
-    return timeout;
+  public Duration getMaxWaitTime() {
+    return maxWaitTime;
   }
 }

--- a/src/main/java/dev/failsafe/RateLimiterConfig.java
+++ b/src/main/java/dev/failsafe/RateLimiterConfig.java
@@ -19,7 +19,7 @@ import java.time.Duration;
 
 public class RateLimiterConfig<R> extends PolicyConfig<R> {
   // Smoothing
-  Duration executionRate;
+  Duration maxRate;
 
   // Bursting
   long maxPermits;
@@ -28,8 +28,8 @@ public class RateLimiterConfig<R> extends PolicyConfig<R> {
   // Common
   Duration maxWaitTime;
 
-  RateLimiterConfig(Duration executionRate) {
-    this.executionRate = executionRate;
+  RateLimiterConfig(Duration maxRate) {
+    this.maxRate = maxRate;
   }
 
   RateLimiterConfig(long maxPermits, Duration period) {
@@ -39,27 +39,28 @@ public class RateLimiterConfig<R> extends PolicyConfig<R> {
 
   RateLimiterConfig(RateLimiterConfig<R> config) {
     super(config);
-    executionRate = config.executionRate;
+    maxRate = config.maxRate;
     maxPermits = config.maxPermits;
     period = config.period;
     maxWaitTime = config.maxWaitTime;
   }
 
   /**
-   * For smooth rate limiters, returns the rate at which executions are permitted, else {@code null} if the rate limiter
-   * is not smooth.
+   * For smooth rate limiters, returns the max rate at which individual executions are permitted, else {@code null} if
+   * the rate limiter is not smooth.
    *
-   * @see RateLimiter#builder(Duration)
+   * @see RateLimiter#smoothBuilder(long, Duration)
+   * @see RateLimiter#smoothBuilder(Duration)
    */
-  public Duration getExecutionRate() {
-    return executionRate;
+  public Duration getMaxRate() {
+    return maxRate;
   }
 
   /**
    * For bursty rate limiters, returns the max permitted executions per {@link #getPeriod() period}, else {@code null}
    * if the rate limiter is not bursty.
    *
-   * @see RateLimiter#builder(long, Duration)
+   * @see RateLimiter#burstyBuilder(long, Duration)
    */
   public long getMaxPermits() {
     return maxPermits;
@@ -69,7 +70,7 @@ public class RateLimiterConfig<R> extends PolicyConfig<R> {
    * For bursty rate limiters, returns the period after which permits are reset to {@link #getMaxPermits() maxPermits},
    * else {@code null} if the rate limiter is not bursty.
    *
-   * @see RateLimiter#builder(long, Duration)
+   * @see RateLimiter#burstyBuilder(long, Duration)
    */
   public Duration getPeriod() {
     return period;

--- a/src/main/java/dev/failsafe/internal/BurstyRateLimiterStats.java
+++ b/src/main/java/dev/failsafe/internal/BurstyRateLimiterStats.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package dev.failsafe.internal;
+
+import dev.failsafe.RateLimiterConfig;
+
+import java.time.Duration;
+
+/**
+ * A rate limiter implementation that allows bursts of executions, up to the max permits per period. This implementation
+ * tracks the current period and available permits, which can go into a deficit. A deficit of available permits will
+ * cause wait times for callers that can be several periods long, depending on the size of the deficit and the number of
+ * requested permits.
+ */
+class BurstyRateLimiterStats extends RateLimiterStats {
+  /* The permits per period */
+  final long periodPermits;
+  /* The nanos per period */
+  private final long periodNanos;
+
+  /* Available permits. Can be negative during a deficit. */
+  private long availablePermits;
+  private long currentPeriod;
+
+  BurstyRateLimiterStats(RateLimiterConfig<?> config, Stopwatch stopwatch) {
+    super(stopwatch);
+    periodPermits = config.getMaxPermits();
+    periodNanos = config.getPeriod().toNanos();
+    availablePermits = periodPermits;
+  }
+
+  /**
+   * Must be externally guarded.
+   */
+  @Override
+  public synchronized long acquirePermits(long requestedPermits, Duration timeout) {
+    long currentNanos = stopwatch.elapsedNanos();
+    long newCurrentPeriod = currentNanos / periodNanos;
+
+    // Update current period and available permits
+    if (currentPeriod < newCurrentPeriod) {
+      long elapsedPeriods = newCurrentPeriod - currentPeriod;
+      long elapsedPermits = elapsedPeriods * periodPermits;
+      currentPeriod = newCurrentPeriod;
+      availablePermits = availablePermits < 0 ? availablePermits + elapsedPermits : periodPermits;
+    }
+
+    long waitNanos = 0;
+    if (requestedPermits > availablePermits) {
+      long nextPeriodNanos = (currentPeriod + 1) * periodNanos;
+      long nanosToNextPeriod = nextPeriodNanos - currentNanos;
+      long permitDeficit = requestedPermits - availablePermits;
+      long additionalPeriods = permitDeficit / periodPermits;
+      long additionalUnits = permitDeficit % periodPermits;
+
+      // Do not wait for an additional period if we're not using any permits from it
+      if (additionalUnits == 0)
+        additionalPeriods -= 1;
+
+      // The nanos to wait until the beginning of the next period that will have free permits
+      waitNanos = nanosToNextPeriod + (additionalPeriods * periodNanos);
+
+      if (exceedsTimeout(waitNanos, timeout))
+        return -1;
+    }
+
+    availablePermits -= requestedPermits;
+    return waitNanos;
+  }
+
+  synchronized long getAvailablePermits() {
+    return availablePermits;
+  }
+
+  synchronized long getCurrentPeriod() {
+    return currentPeriod;
+  }
+
+  @Override
+  synchronized void reset() {
+    stopwatch.reset();
+    availablePermits = periodPermits;
+    currentPeriod = 0;
+  }
+}

--- a/src/main/java/dev/failsafe/internal/BurstyRateLimiterStats.java
+++ b/src/main/java/dev/failsafe/internal/BurstyRateLimiterStats.java
@@ -42,11 +42,8 @@ class BurstyRateLimiterStats extends RateLimiterStats {
     availablePermits = periodPermits;
   }
 
-  /**
-   * Must be externally guarded.
-   */
   @Override
-  public synchronized long acquirePermits(long requestedPermits, Duration timeout) {
+  public synchronized long acquirePermits(long requestedPermits, Duration maxWaitTime) {
     long currentNanos = stopwatch.elapsedNanos();
     long newCurrentPeriod = currentNanos / periodNanos;
 
@@ -73,7 +70,7 @@ class BurstyRateLimiterStats extends RateLimiterStats {
       // The nanos to wait until the beginning of the next period that will have free permits
       waitNanos = nanosToNextPeriod + (additionalPeriods * periodNanos);
 
-      if (exceedsTimeout(waitNanos, timeout))
+      if (exceedsMaxWaitTime(waitNanos, maxWaitTime))
         return -1;
     }
 

--- a/src/main/java/dev/failsafe/internal/RateLimiterExecutor.java
+++ b/src/main/java/dev/failsafe/internal/RateLimiterExecutor.java
@@ -41,9 +41,9 @@ public class RateLimiterExecutor<R> extends PolicyExecutor<R> {
   @Override
   protected ExecutionResult<R> preExecute() {
     try {
-      boolean acquired =
-        maxWaitTime == null ? rateLimiter.tryAcquirePermit() : rateLimiter.tryAcquirePermit(maxWaitTime);
-      return acquired ? null : ExecutionResult.failure(new RateLimitExceededException(rateLimiter));
+      return rateLimiter.tryAcquirePermit(maxWaitTime) ?
+        null :
+        ExecutionResult.failure(new RateLimitExceededException(rateLimiter));
     } catch (InterruptedException e) {
       // Set interrupt flag
       Thread.currentThread().interrupt();

--- a/src/main/java/dev/failsafe/internal/RateLimiterExecutor.java
+++ b/src/main/java/dev/failsafe/internal/RateLimiterExecutor.java
@@ -30,18 +30,19 @@ import java.time.Duration;
  */
 public class RateLimiterExecutor<R> extends PolicyExecutor<R> {
   private final RateLimiterImpl<R> rateLimiter;
-  private final Duration timeout;
+  private final Duration maxWaitTime;
 
   public RateLimiterExecutor(RateLimiterImpl<R> rateLimiter, int policyIndex) {
     super(rateLimiter, policyIndex);
     this.rateLimiter = rateLimiter;
-    timeout = rateLimiter.getConfig().getTimeout();
+    maxWaitTime = rateLimiter.getConfig().getMaxWaitTime();
   }
 
   @Override
   protected ExecutionResult<R> preExecute() {
     try {
-      boolean acquired = timeout == null ? rateLimiter.tryAcquirePermit() : rateLimiter.tryAcquirePermit(timeout);
+      boolean acquired =
+        maxWaitTime == null ? rateLimiter.tryAcquirePermit() : rateLimiter.tryAcquirePermit(maxWaitTime);
       return acquired ? null : ExecutionResult.failure(new RateLimitExceededException(rateLimiter));
     } catch (InterruptedException e) {
       // Set interrupt flag

--- a/src/main/java/dev/failsafe/internal/RateLimiterExecutor.java
+++ b/src/main/java/dev/failsafe/internal/RateLimiterExecutor.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package dev.failsafe.internal;
+
+import dev.failsafe.RateLimitExceededException;
+import dev.failsafe.RateLimiter;
+import dev.failsafe.spi.ExecutionResult;
+import dev.failsafe.spi.PolicyExecutor;
+
+import java.time.Duration;
+
+/**
+ * A PolicyExecutor that handles failures according to a {@link RateLimiter}.
+ *
+ * @param <R> result type
+ * @author Jonathan Halterman
+ */
+public class RateLimiterExecutor<R> extends PolicyExecutor<R> {
+  private final RateLimiterImpl<R> rateLimiter;
+  private final Duration timeout;
+
+  public RateLimiterExecutor(RateLimiterImpl<R> rateLimiter, int policyIndex) {
+    super(rateLimiter, policyIndex);
+    this.rateLimiter = rateLimiter;
+    timeout = rateLimiter.getConfig().getTimeout();
+  }
+
+  @Override
+  protected ExecutionResult<R> preExecute() {
+    try {
+      boolean acquired = timeout == null ? rateLimiter.tryAcquirePermit() : rateLimiter.tryAcquirePermit(timeout);
+      return acquired ? null : ExecutionResult.failure(new RateLimitExceededException(rateLimiter));
+    } catch (InterruptedException e) {
+      // Set interrupt flag
+      Thread.currentThread().interrupt();
+      return ExecutionResult.failure(e);
+    }
+  }
+
+  @Override
+  public boolean isFailure(ExecutionResult<R> result) {
+    return !result.isNonResult() && result.getFailure() instanceof RateLimitExceededException;
+  }
+}

--- a/src/main/java/dev/failsafe/internal/RateLimiterImpl.java
+++ b/src/main/java/dev/failsafe/internal/RateLimiterImpl.java
@@ -39,7 +39,7 @@ public class RateLimiterImpl<R> implements RateLimiter<R> {
 
   RateLimiterImpl(RateLimiterConfig<R> config, Stopwatch stopwatch) {
     this.config = config;
-    stats = config.getExecutionRate() != null ?
+    stats = config.getMaxRate() != null ?
       new SmoothRateLimiterStats(config, stopwatch) :
       new BurstyRateLimiterStats(config, stopwatch);
   }

--- a/src/main/java/dev/failsafe/internal/RateLimiterImpl.java
+++ b/src/main/java/dev/failsafe/internal/RateLimiterImpl.java
@@ -65,10 +65,10 @@ public class RateLimiterImpl<R> implements RateLimiter<R> {
   }
 
   @Override
-  public boolean tryAcquirePermits(int permits, Duration timeout) throws InterruptedException {
+  public boolean tryAcquirePermits(int permits, Duration maxWaitTime) throws InterruptedException {
     Assert.isTrue(permits > 0, "permits must be > 0");
-    Assert.notNull(timeout, "timeout");
-    long waitNanos = stats.acquirePermits(permits, timeout);
+    Assert.notNull(maxWaitTime, "maxWaitTime");
+    long waitNanos = stats.acquirePermits(permits, maxWaitTime);
     if (waitNanos == -1)
       return false;
     if (waitNanos > 0)

--- a/src/main/java/dev/failsafe/internal/RateLimiterImpl.java
+++ b/src/main/java/dev/failsafe/internal/RateLimiterImpl.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package dev.failsafe.internal;
+
+import dev.failsafe.RateLimiter;
+import dev.failsafe.RateLimiterConfig;
+import dev.failsafe.internal.RateLimiterStats.Stopwatch;
+import dev.failsafe.internal.util.Assert;
+import dev.failsafe.spi.PolicyExecutor;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A RateLimiter implementation.
+ *
+ * @param <R> result type
+ */
+public class RateLimiterImpl<R> implements RateLimiter<R> {
+  private final RateLimiterConfig<R> config;
+  private final RateLimiterStats stats;
+
+  public RateLimiterImpl(RateLimiterConfig<R> config) {
+    this(config, new Stopwatch());
+  }
+
+  RateLimiterImpl(RateLimiterConfig<R> config, Stopwatch stopwatch) {
+    this.config = config;
+    stats = config.getExecutionRate() != null ?
+      new SmoothRateLimiterStats(config, stopwatch) :
+      new BurstyRateLimiterStats(config, stopwatch);
+  }
+
+  @Override
+  public RateLimiterConfig<R> getConfig() {
+    return config;
+  }
+
+  @Override
+  public void acquirePermits(int permits) throws InterruptedException {
+    Assert.isTrue(permits > 0, "permits must be > 0");
+    long waitNanos = stats.acquirePermits(permits, null);
+    if (waitNanos > 0)
+      TimeUnit.NANOSECONDS.sleep(waitNanos);
+  }
+
+  @Override
+  public boolean tryAcquirePermits(int permits) {
+    Assert.isTrue(permits > 0, "permits must be > 0");
+    long waitNanos = stats.acquirePermits(permits, Duration.ZERO);
+    return waitNanos == 0;
+  }
+
+  @Override
+  public boolean tryAcquirePermits(int permits, Duration timeout) throws InterruptedException {
+    Assert.isTrue(permits > 0, "permits must be > 0");
+    Assert.notNull(timeout, "timeout");
+    long waitNanos = stats.acquirePermits(permits, timeout);
+    if (waitNanos == -1)
+      return false;
+    if (waitNanos > 0)
+      TimeUnit.NANOSECONDS.sleep(waitNanos);
+    return true;
+  }
+
+  @Override
+  public PolicyExecutor<R> toExecutor(int policyIndex) {
+    return new RateLimiterExecutor<>(this, policyIndex);
+  }
+}

--- a/src/main/java/dev/failsafe/internal/RateLimiterStats.java
+++ b/src/main/java/dev/failsafe/internal/RateLimiterStats.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package dev.failsafe.internal;
+
+import java.time.Duration;
+
+abstract class RateLimiterStats {
+  final Stopwatch stopwatch;
+
+  RateLimiterStats(Stopwatch stopwatch) {
+    this.stopwatch = stopwatch;
+  }
+
+  static class Stopwatch {
+    private long startTime = System.nanoTime();
+
+    long elapsedNanos() {
+      return System.nanoTime() - startTime;
+    }
+
+    void reset() {
+      startTime = System.nanoTime();
+    }
+  }
+
+  /**
+   * Eagerly acquires permits and returns the time in nanos that must be waited in order to use the permits, else
+   * returns {@code -1} if the wait time would exceed the {@code timeout}.
+   *
+   * @param permits the number of requested permits
+   * @param timeout the max time to wait for the requested permits, else {@code null} to wait indefinitely
+   */
+  abstract long acquirePermits(long permits, Duration timeout);
+
+  /**
+   * Returns whether the {@code waitNanos} would exceed the {@code timeout}, else {@code false} if {@code timeout} is
+   * null.
+   */
+  boolean exceedsTimeout(long waitNanos, Duration timeout) {
+    return timeout != null && waitNanos > timeout.toNanos();
+  }
+
+  /**
+   * Returns the elapsed time since the rate limiter began.
+   */
+  Duration getElapsed() {
+    return Duration.ofNanos(stopwatch.elapsedNanos());
+  }
+
+  /**
+   * Resets the rate limiter's internal stats.
+   */
+  abstract void reset();
+}

--- a/src/main/java/dev/failsafe/internal/RateLimiterStats.java
+++ b/src/main/java/dev/failsafe/internal/RateLimiterStats.java
@@ -38,19 +38,19 @@ abstract class RateLimiterStats {
 
   /**
    * Eagerly acquires permits and returns the time in nanos that must be waited in order to use the permits, else
-   * returns {@code -1} if the wait time would exceed the {@code timeout}.
+   * returns {@code -1} if the wait time would exceed the {@code maxWaitTime}.
    *
    * @param permits the number of requested permits
-   * @param timeout the max time to wait for the requested permits, else {@code null} to wait indefinitely
+   * @param maxWaitTime the max time to wait for the requested permits, else {@code null} to wait indefinitely
    */
-  abstract long acquirePermits(long permits, Duration timeout);
+  abstract long acquirePermits(long permits, Duration maxWaitTime);
 
   /**
-   * Returns whether the {@code waitNanos} would exceed the {@code timeout}, else {@code false} if {@code timeout} is
-   * null.
+   * Returns whether the {@code waitNanos} would exceed the {@code maxWaitTime}, else {@code false} if {@code
+   * maxWaitTime} is null.
    */
-  boolean exceedsTimeout(long waitNanos, Duration timeout) {
-    return timeout != null && waitNanos > timeout.toNanos();
+  boolean exceedsMaxWaitTime(long waitNanos, Duration maxWaitTime) {
+    return maxWaitTime != null && waitNanos > maxWaitTime.toNanos();
   }
 
   /**

--- a/src/main/java/dev/failsafe/internal/RetryPolicyExecutor.java
+++ b/src/main/java/dev/failsafe/internal/RetryPolicyExecutor.java
@@ -89,10 +89,10 @@ public class RetryPolicyExecutor<R> extends PolicyExecutor<R> {
           execution.setInterruptable(true);
           Thread.sleep(TimeUnit.NANOSECONDS.toMillis(result.getDelay()));
         } catch (InterruptedException e) {
-          // Set interrupt flag if interrupt was not intended
+          // Set interrupt flag if interruption was not performed by Failsafe
           if (!execution.isInterrupted())
             Thread.currentThread().interrupt();
-          return ExecutionResult.failure(new FailsafeException(e));
+          return ExecutionResult.failure(e);
         } finally {
           execution.setInterruptable(false);
         }

--- a/src/main/java/dev/failsafe/internal/SmoothRateLimiterStats.java
+++ b/src/main/java/dev/failsafe/internal/SmoothRateLimiterStats.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package dev.failsafe.internal;
+
+import dev.failsafe.RateLimiterConfig;
+import dev.failsafe.internal.util.Maths;
+
+import java.time.Duration;
+
+/**
+ * A rate limiter implementation that evenly distributes permits over time, based on the max permits per period. This
+ * implementation focuses on the interval between permits, and tracks the next interval in which a permit is free.
+ */
+class SmoothRateLimiterStats extends RateLimiterStats {
+  /* The nanos per interval between permits */
+  final long intervalNanos;
+
+  // The amount of time, relative to the start time, that the next permit will be free.
+  // Will be a multiple of intervalNanos.
+  private long nextFreePermitNanos;
+
+  SmoothRateLimiterStats(RateLimiterConfig<?> config, Stopwatch stopwatch) {
+    super(stopwatch);
+    intervalNanos = config.getExecutionRate().toNanos();
+  }
+
+  @Override
+  public synchronized long acquirePermits(long requestedPermits, Duration timeout) {
+    long currentNanos = stopwatch.elapsedNanos();
+    long requestedPermitNanos = requestedPermits * intervalNanos;
+    long waitNanos;
+    long newNextFreePermitNanos;
+
+    // If a permit is currently available
+    if (currentNanos >= nextFreePermitNanos) {
+      // Nanos at the start of the current interval
+      long currentIntervalNanos = Maths.roundDown(currentNanos, intervalNanos);
+      newNextFreePermitNanos = Maths.add(currentIntervalNanos, requestedPermitNanos);
+    } else {
+      newNextFreePermitNanos = Maths.add(nextFreePermitNanos, requestedPermitNanos);
+    }
+
+    waitNanos = Math.max(newNextFreePermitNanos - currentNanos - intervalNanos, 0);
+
+    if (exceedsTimeout(waitNanos, timeout))
+      return -1;
+
+    nextFreePermitNanos = newNextFreePermitNanos;
+    return waitNanos;
+  }
+
+  synchronized long getNextFreePermitNanos() {
+    return nextFreePermitNanos;
+  }
+
+  @Override
+  synchronized void reset() {
+    stopwatch.reset();
+    nextFreePermitNanos = 0;
+  }
+}

--- a/src/main/java/dev/failsafe/internal/SmoothRateLimiterStats.java
+++ b/src/main/java/dev/failsafe/internal/SmoothRateLimiterStats.java
@@ -34,11 +34,11 @@ class SmoothRateLimiterStats extends RateLimiterStats {
 
   SmoothRateLimiterStats(RateLimiterConfig<?> config, Stopwatch stopwatch) {
     super(stopwatch);
-    intervalNanos = config.getExecutionRate().toNanos();
+    intervalNanos = config.getMaxRate().toNanos();
   }
 
   @Override
-  public synchronized long acquirePermits(long requestedPermits, Duration timeout) {
+  public synchronized long acquirePermits(long requestedPermits, Duration maxWaitTime) {
     long currentNanos = stopwatch.elapsedNanos();
     long requestedPermitNanos = requestedPermits * intervalNanos;
     long waitNanos;
@@ -55,7 +55,7 @@ class SmoothRateLimiterStats extends RateLimiterStats {
 
     waitNanos = Math.max(newNextFreePermitNanos - currentNanos - intervalNanos, 0);
 
-    if (exceedsTimeout(waitNanos, timeout))
+    if (exceedsMaxWaitTime(waitNanos, maxWaitTime))
       return -1;
 
     nextFreePermitNanos = newNextFreePermitNanos;

--- a/src/main/java/dev/failsafe/internal/util/Maths.java
+++ b/src/main/java/dev/failsafe/internal/util/Maths.java
@@ -1,0 +1,24 @@
+package dev.failsafe.internal.util;
+
+/**
+ * Misc math utilities.
+ */
+public final class Maths {
+  private Maths() {
+  }
+
+  /**
+   * Returns the sum of {@code a} and {@code b} else {@code Long.MAX_VALUE} if the sum would otherwise overflow.
+   */
+  public static long add(long a, long b) {
+    long naiveSum = a + b;
+    return (a ^ b) < 0L | (a ^ naiveSum) >= 0L ? naiveSum : 9223372036854775807L + (naiveSum >>> 63 ^ 1L);
+  }
+
+  /**
+   * Returns the {@code input} rounded down to the nearest {@code interval}.
+   */
+  public static long roundDown(long input, long interval) {
+    return (input / interval) * interval;
+  }
+}

--- a/src/test/java/dev/failsafe/CircuitBreakerBuilderTest.java
+++ b/src/test/java/dev/failsafe/CircuitBreakerBuilderTest.java
@@ -19,6 +19,7 @@ import org.testng.annotations.Test;
 
 import java.time.Duration;
 
+import static dev.failsafe.testing.Asserts.assertThrows;
 import static org.testng.Assert.*;
 
 @Test
@@ -37,5 +38,30 @@ public class CircuitBreakerBuilderTest {
     assertEquals(newConfig.successThreshold, 20);
     assertEquals(newConfig.successThresholdingCapacity, 30);
     assertNotNull(newConfig.closeListener);
+  }
+
+  public void shouldRequireValidDelay() {
+    assertThrows(() -> CircuitBreaker.builder().withDelay(null), NullPointerException.class);
+    assertThrows(() -> CircuitBreaker.builder().withDelay(Duration.ofMillis(-1)), IllegalArgumentException.class);
+  }
+
+  public void shouldRequireValidFailureThreshold() {
+    assertThrows(() -> CircuitBreaker.builder().withFailureThreshold(0), IllegalArgumentException.class);
+  }
+
+  public void shouldRequireValidFailureThresholdRatio() {
+    assertThrows(() -> CircuitBreaker.builder().withFailureThreshold(0, 2), IllegalArgumentException.class);
+    assertThrows(() -> CircuitBreaker.builder().withFailureThreshold(2, 0), IllegalArgumentException.class);
+    assertThrows(() -> CircuitBreaker.builder().withFailureThreshold(2, 1), IllegalArgumentException.class);
+  }
+
+  public void shouldRequireValidSuccessThreshold() {
+    assertThrows(() -> CircuitBreaker.builder().withSuccessThreshold(0).build(), IllegalArgumentException.class);
+  }
+
+  public void shouldRequireValidSuccessThresholdRatio() {
+    assertThrows(() -> CircuitBreaker.builder().withSuccessThreshold(0, 2), IllegalArgumentException.class);
+    assertThrows(() -> CircuitBreaker.builder().withSuccessThreshold(2, 0), IllegalArgumentException.class);
+    assertThrows(() -> CircuitBreaker.builder().withSuccessThreshold(2, 1), IllegalArgumentException.class);
   }
 }

--- a/src/test/java/dev/failsafe/CircuitBreakerTest.java
+++ b/src/test/java/dev/failsafe/CircuitBreakerTest.java
@@ -25,32 +25,6 @@ import static org.testng.Assert.assertTrue;
 
 @Test
 public class CircuitBreakerTest {
-  public void shouldRequireValidDelay() {
-    assertThrows(() -> CircuitBreaker.builder().withDelay(null).build(), NullPointerException.class);
-    assertThrows(() -> CircuitBreaker.builder().withDelay(Duration.ofMillis(-1)).build(),
-      IllegalArgumentException.class);
-  }
-
-  public void shouldRequireValidFailureThreshold() {
-    assertThrows(() -> CircuitBreaker.builder().withFailureThreshold(0).build(), IllegalArgumentException.class);
-  }
-
-  public void shouldRequireValidFailureThresholdRatio() {
-    assertThrows(() -> CircuitBreaker.builder().withFailureThreshold(0, 2).build(), IllegalArgumentException.class);
-    assertThrows(() -> CircuitBreaker.builder().withFailureThreshold(2, 0).build(), IllegalArgumentException.class);
-    assertThrows(() -> CircuitBreaker.builder().withFailureThreshold(2, 1).build(), IllegalArgumentException.class);
-  }
-
-  public void shouldRequireValidSuccessThreshold() {
-    assertThrows(() -> CircuitBreaker.builder().withSuccessThreshold(0).build(), IllegalArgumentException.class);
-  }
-
-  public void shouldRequireValidSuccessThresholdRatio() {
-    assertThrows(() -> CircuitBreaker.builder().withSuccessThreshold(0, 2).build(), IllegalArgumentException.class);
-    assertThrows(() -> CircuitBreaker.builder().withSuccessThreshold(2, 0).build(), IllegalArgumentException.class);
-    assertThrows(() -> CircuitBreaker.builder().withSuccessThreshold(2, 1).build(), IllegalArgumentException.class);
-  }
-
   public void shouldDefaultDelay() throws Throwable {
     CircuitBreaker<Object> breaker = CircuitBreaker.ofDefaults();
     breaker.recordFailure();

--- a/src/test/java/dev/failsafe/RateLimiterBuilderTest.java
+++ b/src/test/java/dev/failsafe/RateLimiterBuilderTest.java
@@ -26,12 +26,12 @@ import static org.testng.Assert.assertNotNull;
 public class RateLimiterBuilderTest {
   public void shouldCreateBuilderFromExistingConfig() {
     RateLimiterConfig<Object> initialConfig = RateLimiter.builder(Duration.ofMillis(10))
-      .withTimeout(Duration.ofSeconds(10))
+      .withMaxWaitTime(Duration.ofSeconds(10))
       .onSuccess(e -> {
       }).config;
     RateLimiterConfig<Object> newConfig = RateLimiter.builder(initialConfig).config;
     assertEquals(newConfig.executionRate, Duration.ofMillis(10));
-    assertEquals(newConfig.timeout, Duration.ofSeconds(10));
+    assertEquals(newConfig.maxWaitTime, Duration.ofSeconds(10));
     assertNotNull(newConfig.successListener);
   }
 }

--- a/src/test/java/dev/failsafe/RateLimiterBuilderTest.java
+++ b/src/test/java/dev/failsafe/RateLimiterBuilderTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package dev.failsafe;
+
+import org.testng.annotations.Test;
+
+import java.time.Duration;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+@Test
+public class RateLimiterBuilderTest {
+  public void shouldCreateBuilderFromExistingConfig() {
+    RateLimiterConfig<Object> initialConfig = RateLimiter.builder(Duration.ofMillis(10))
+      .withTimeout(Duration.ofSeconds(10))
+      .onSuccess(e -> {
+      }).config;
+    RateLimiterConfig<Object> newConfig = RateLimiter.builder(initialConfig).config;
+    assertEquals(newConfig.executionRate, Duration.ofMillis(10));
+    assertEquals(newConfig.timeout, Duration.ofSeconds(10));
+    assertNotNull(newConfig.successListener);
+  }
+}

--- a/src/test/java/dev/failsafe/RateLimiterBuilderTest.java
+++ b/src/test/java/dev/failsafe/RateLimiterBuilderTest.java
@@ -25,13 +25,26 @@ import static org.testng.Assert.assertNotNull;
 @Test
 public class RateLimiterBuilderTest {
   public void shouldCreateBuilderFromExistingConfig() {
-    RateLimiterConfig<Object> initialConfig = RateLimiter.builder(Duration.ofMillis(10))
+    RateLimiterConfig<Object> initialConfig = RateLimiter.smoothBuilder(Duration.ofMillis(10))
       .withMaxWaitTime(Duration.ofSeconds(10))
       .onSuccess(e -> {
       }).config;
     RateLimiterConfig<Object> newConfig = RateLimiter.builder(initialConfig).config;
-    assertEquals(newConfig.executionRate, Duration.ofMillis(10));
+    assertEquals(newConfig.maxRate, Duration.ofMillis(10));
     assertEquals(newConfig.maxWaitTime, Duration.ofSeconds(10));
     assertNotNull(newConfig.successListener);
+  }
+
+  /**
+   * Asserts that the smooth rate limiter factory methods are equal.
+   */
+  public void shouldBuildEqualSmoothLimiters() {
+    Duration maxRate1 = RateLimiter.smoothBuilder(100, Duration.ofSeconds(1)).config.getMaxRate();
+    Duration maxRate2 = RateLimiter.smoothBuilder(Duration.ofMillis(10)).config.getMaxRate();
+    assertEquals(maxRate1, maxRate2);
+
+    maxRate1 = RateLimiter.smoothBuilder(20, Duration.ofMillis(300)).config.getMaxRate();
+    maxRate2 = RateLimiter.smoothBuilder(Duration.ofMillis(15)).config.getMaxRate();
+    assertEquals(maxRate1, maxRate2);
   }
 }

--- a/src/test/java/dev/failsafe/functional/RateLimiterTest.java
+++ b/src/test/java/dev/failsafe/functional/RateLimiterTest.java
@@ -15,7 +15,10 @@
  */
 package dev.failsafe.functional;
 
-import dev.failsafe.*;
+import dev.failsafe.Failsafe;
+import dev.failsafe.RateLimitExceededException;
+import dev.failsafe.RateLimiter;
+import dev.failsafe.RetryPolicy;
 import dev.failsafe.testing.Testing;
 import org.testng.annotations.Test;
 
@@ -23,7 +26,6 @@ import java.time.Duration;
 
 import static dev.failsafe.internal.InternalTesting.resetLimiter;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 
 /**
  * Tests various RateLimiter scenarios.
@@ -32,7 +34,7 @@ import static org.testng.Assert.assertTrue;
 public class RateLimiterTest extends Testing {
   public void shouldThrowRateLimitExceededExceptionAfterPermitsExceeded() {
     // Given
-    RateLimiter<Object> limiter = RateLimiter.builder(Duration.ofMillis(100)).build();
+    RateLimiter<Object> limiter = RateLimiter.smoothBuilder(Duration.ofMillis(100)).build();
 
     // When / Then
     testRunFailure(() -> {
@@ -47,7 +49,7 @@ public class RateLimiterTest extends Testing {
    */
   public void testMaxWaitTimeExceeded() {
     // Given
-    RateLimiter<Object> limiter = RateLimiter.builder(Duration.ofMillis(10))
+    RateLimiter<Object> limiter = RateLimiter.smoothBuilder(Duration.ofMillis(10))
       .withMaxWaitTime(Duration.ofMillis(20))
       .build();
 
@@ -70,7 +72,7 @@ public class RateLimiterTest extends Testing {
     Stats rpStats = new Stats();
     Stats rlStats = new Stats();
     RetryPolicy<Object> rp = withStatsAndLogs(RetryPolicy.builder().withMaxAttempts(7), rpStats).build();
-    RateLimiter<Object> rl = withStatsAndLogs(RateLimiter.builder(3, Duration.ofSeconds(1)), rlStats).build();
+    RateLimiter<Object> rl = withStatsAndLogs(RateLimiter.burstyBuilder(3, Duration.ofSeconds(1)), rlStats).build();
 
     testRunFailure(() -> {
       rpStats.reset();
@@ -91,7 +93,7 @@ public class RateLimiterTest extends Testing {
    * Asserts that a rate limiter propagates an InterruptedException.
    */
   public void testAcquirePermitWithInterrupt() {
-    RateLimiter<Object> limiter = RateLimiter.builder(Duration.ofSeconds(1))
+    RateLimiter<Object> limiter = RateLimiter.smoothBuilder(Duration.ofSeconds(1))
       .withMaxWaitTime(Duration.ofSeconds(5))
       .build();
 

--- a/src/test/java/dev/failsafe/functional/RateLimiterTest.java
+++ b/src/test/java/dev/failsafe/functional/RateLimiterTest.java
@@ -45,6 +45,23 @@ public class RateLimiterTest extends Testing {
   }
 
   /**
+   * Asserts that an exceeded timeout causes RateLimitExceededException.
+   */
+  public void testTimeoutExceeded() {
+    // Given
+    RateLimiter<Object> limiter = RateLimiter.builder(Duration.ofMillis(10)).withTimeout(Duration.ofMillis(20)).build();
+
+    // When / Then
+    testRunFailure(() -> {
+      resetLimiter(limiter);
+      runInThread(() -> {
+        limiter.tryAcquirePermits(5, Duration.ofSeconds(1)); // limiter should now be 4 permits over its max
+      });
+    }, Failsafe.with(limiter), ctx -> {
+    }, RateLimitExceededException.class);
+  }
+
+  /**
    * Tests a scenario where RateLimiter rejects some retried executions, which prevents the user's Supplier from being
    * called.
    */

--- a/src/test/java/dev/failsafe/functional/RateLimiterTest.java
+++ b/src/test/java/dev/failsafe/functional/RateLimiterTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package dev.failsafe.functional;
+
+import dev.failsafe.*;
+import dev.failsafe.internal.RateLimiterImpl;
+import dev.failsafe.testing.Testing;
+import org.testng.annotations.Test;
+
+import java.time.Duration;
+
+import static dev.failsafe.internal.InternalTesting.resetBreaker;
+import static dev.failsafe.internal.InternalTesting.resetLimiter;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests various RateLimiter scenarios.
+ */
+@Test
+public class RateLimiterTest extends Testing {
+  public void shouldThrowRateLimitExceededExceptionAfterPermitsExceeded() {
+    // Given
+    RateLimiter<Object> limiter = RateLimiter.builder(Duration.ofMillis(100)).build();
+
+    // When / Then
+    testRunFailure(() -> {
+      resetLimiter(limiter);
+      limiter.tryAcquirePermit(); // limiter should now be out of permits
+    }, Failsafe.with(limiter), ctx -> {
+    }, RateLimitExceededException.class);
+  }
+
+  /**
+   * Tests a scenario where RateLimiter rejects some retried executions, which prevents the user's Supplier from being
+   * called.
+   */
+  public void testRejectedWithRetries() {
+    Stats rpStats = new Stats();
+    Stats rlStats = new Stats();
+    RetryPolicy<Object> rp = withStatsAndLogs(RetryPolicy.builder().withMaxAttempts(7), rpStats).build();
+    RateLimiter<Object> rl = withStatsAndLogs(RateLimiter.builder(3, Duration.ofSeconds(1)), rlStats).build();
+
+    testRunFailure(() -> {
+      rpStats.reset();
+      rlStats.reset();
+      resetLimiter(rl);
+    }, Failsafe.with(rp, rl), ctx -> {
+      System.out.println("Executing");
+      throw new Exception();
+    }, (f, e) -> {
+      assertEquals(e.getAttemptCount(), 7);
+      assertEquals(e.getExecutionCount(), 3);
+      assertEquals(rpStats.failedAttemptCount, 7);
+      assertEquals(rpStats.retryCount, 6);
+    }, RateLimitExceededException.class);
+  }
+
+  /**
+   * Asserts that a rate limiter propagates an InterruptedException.
+   */
+  public void testAcquirePermitWithInterrupt() {
+    RateLimiter<Object> limiter = RateLimiter.builder(Duration.ofSeconds(1)).withTimeout(Duration.ofSeconds(5)).build();
+
+    testRunFailure(() -> {
+      resetLimiter(limiter);
+      limiter.tryAcquirePermit();
+      Thread thread = Thread.currentThread();
+      runInThread(() -> {
+        Thread.sleep(100);
+        thread.interrupt();
+      });
+    }, Failsafe.with(limiter), ctx -> {
+      System.out.println("Executing");
+      throw new Exception();
+    }, InterruptedException.class);
+  }
+}

--- a/src/test/java/dev/failsafe/internal/BurstyRateLimiterStatsTest.java
+++ b/src/test/java/dev/failsafe/internal/BurstyRateLimiterStatsTest.java
@@ -27,12 +27,12 @@ import static org.testng.Assert.assertEquals;
 public class BurstyRateLimiterStatsTest extends RateLimiterStatsTest<BurstyRateLimiterStats> {
   @Override
   BurstyRateLimiterStats createStats() {
-    RateLimiterConfig<Object> config = RateLimiter.builder(2, Duration.ofSeconds(1)).build().getConfig();
+    RateLimiterConfig<Object> config = RateLimiter.burstyBuilder(2, Duration.ofSeconds(1)).build().getConfig();
     return new BurstyRateLimiterStats(config, stopwatch);
   }
 
   BurstyRateLimiterStats createStats(long maxPermits, Duration period) {
-    RateLimiterConfig<Object> config = RateLimiter.builder(maxPermits, period).build().getConfig();
+    RateLimiterConfig<Object> config = RateLimiter.burstyBuilder(maxPermits, period).build().getConfig();
     return new BurstyRateLimiterStats(config, stopwatch);
   }
 

--- a/src/test/java/dev/failsafe/internal/BurstyRateLimiterStatsTest.java
+++ b/src/test/java/dev/failsafe/internal/BurstyRateLimiterStatsTest.java
@@ -20,7 +20,6 @@ import dev.failsafe.RateLimiterConfig;
 import org.testng.annotations.Test;
 
 import java.time.Duration;
-import java.util.concurrent.TimeUnit;
 
 import static org.testng.Assert.assertEquals;
 

--- a/src/test/java/dev/failsafe/internal/BurstyRateLimiterStatsTest.java
+++ b/src/test/java/dev/failsafe/internal/BurstyRateLimiterStatsTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package dev.failsafe.internal;
+
+import dev.failsafe.RateLimiter;
+import dev.failsafe.RateLimiterConfig;
+import org.testng.annotations.Test;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import static org.testng.Assert.assertEquals;
+
+@Test
+public class BurstyRateLimiterStatsTest extends RateLimiterStatsTest<BurstyRateLimiterStats> {
+  @Override
+  BurstyRateLimiterStats createStats() {
+    RateLimiterConfig<Object> config = RateLimiter.builder(2, Duration.ofSeconds(1)).build().getConfig();
+    return new BurstyRateLimiterStats(config, stopwatch);
+  }
+
+  BurstyRateLimiterStats createStats(long maxPermits, Duration period) {
+    RateLimiterConfig<Object> config = RateLimiter.builder(maxPermits, period).build().getConfig();
+    return new BurstyRateLimiterStats(config, stopwatch);
+  }
+
+  /**
+   * Asserts that wait times and available permits are expected, over time, when calling acquirePermits.
+   */
+  public void testAcquirePermits() {
+    // Given 2 max permits per second
+    BurstyRateLimiterStats stats = createStats(2, Duration.ofSeconds(1));
+
+    assertEquals(acquire(stats, 1, 7), 3000);
+    assertEquals(stats.getAvailablePermits(), -5);
+    assertEquals(stats.getCurrentPeriod(), 0);
+
+    stopwatch.set(800);
+    assertEquals(acquire(stats, 3), 3200);
+    assertEquals(stats.getAvailablePermits(), -8);
+    assertEquals(stats.getCurrentPeriod(), 0);
+
+    stopwatch.set(2300);
+    assertEquals(acquire(stats, 1), 2700);
+    assertEquals(stats.getAvailablePermits(), -5);
+    assertEquals(stats.getCurrentPeriod(), 2);
+
+    stopwatch.set(3500);
+    assertEquals(acquire(stats, 1, 3), 2500);
+    assertEquals((stats.getAvailablePermits()), -6);
+    assertEquals(stats.getCurrentPeriod(), 3);
+
+    stopwatch.set(7000);
+    assertEquals(acquire(stats, 1), 0);
+    assertEquals((stats.getAvailablePermits()), 1);
+    assertEquals(stats.getCurrentPeriod(), 7);
+
+    // Given 5 max permits per second
+    stopwatch = new TestStopwatch();
+    stats = createStats(5, Duration.ofSeconds(1));
+
+    stopwatch.set(300);
+    assertEquals(acquire(stats, 3), 0);
+    assertEquals(stats.getAvailablePermits(), 2);
+    assertEquals(stats.getCurrentPeriod(), 0);
+
+    stopwatch.set(1550);
+    assertEquals(acquire(stats, 10), 450);
+    assertEquals(stats.getAvailablePermits(), -5);
+    assertEquals(stats.getCurrentPeriod(), 1);
+
+    stopwatch.set(2210);
+    assertEquals(acquire(stats, 2), 790); // Must wait till next period
+    assertEquals(stats.getAvailablePermits(), -2);
+    assertEquals(stats.getCurrentPeriod(), 2);
+  }
+
+  @Override
+  void printInfo(BurstyRateLimiterStats stats, long waitMillis) {
+    System.out.printf("[%s] elapsedMillis: %5s, availablePermits: %2s, currentPeriod: %s, waitMillis: %s%n",
+      Thread.currentThread().getName(), stats.getElapsed().toMillis(), stats.getAvailablePermits(),
+      stats.getCurrentPeriod(), waitMillis);
+  }
+}

--- a/src/test/java/dev/failsafe/internal/InternalTesting.java
+++ b/src/test/java/dev/failsafe/internal/InternalTesting.java
@@ -1,6 +1,7 @@
 package dev.failsafe.internal;
 
 import dev.failsafe.CircuitBreaker;
+import dev.failsafe.RateLimiter;
 
 import java.lang.reflect.Field;
 import java.util.concurrent.atomic.AtomicReference;
@@ -25,5 +26,17 @@ public final class InternalTesting {
     breaker.close();
     CircuitState<?> state = stateFor(breaker);
     state.getStats().reset();
+  }
+
+  public static void resetLimiter(RateLimiter<?> limiter) {
+    try {
+      RateLimiterImpl<?> impl = (RateLimiterImpl<?>) limiter;
+      Field statsField = RateLimiterImpl.class.getDeclaredField("stats");
+      statsField.setAccessible(true);
+      RateLimiterStats stats = (RateLimiterStats) statsField.get(impl);
+      stats.reset();
+    } catch (Exception e) {
+      throw new IllegalStateException("Could not reset rate limiter");
+    }
   }
 }

--- a/src/test/java/dev/failsafe/internal/RateLimiterImplTest.java
+++ b/src/test/java/dev/failsafe/internal/RateLimiterImplTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package dev.failsafe.internal;
+
+import dev.failsafe.RateLimitExceededException;
+import dev.failsafe.RateLimiter;
+import dev.failsafe.internal.RateLimiterStatsTest.TestStopwatch;
+import dev.failsafe.testing.Testing;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.time.Duration;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+@Test
+public class RateLimiterImplTest extends Testing {
+  static RateLimiter<Object> smoothLimiter = RateLimiter.builder(Duration.ofMillis(500)).build();
+  static RateLimiter<Object> burstyLimiter = RateLimiter.builder(2, Duration.ofSeconds(1)).build();
+  TestStopwatch stopwatch;
+
+  @BeforeMethod
+  protected void beforeMethod() {
+    stopwatch = new TestStopwatch();
+  }
+
+  public void testIsSmooth() {
+    assertTrue(smoothLimiter.isSmooth());
+    assertFalse(smoothLimiter.isBursty());
+  }
+
+  public void testIsBursty() {
+    assertTrue(burstyLimiter.isBursty());
+    assertFalse(burstyLimiter.isSmooth());
+  }
+
+  public void testAcquirePermit() {
+    RateLimiterImpl<Object> limiter = new RateLimiterImpl<>(
+      RateLimiter.builder(Duration.ofMillis(100)).build().getConfig(), stopwatch);
+
+    long elapsed = timed(() -> {
+      limiter.acquirePermit(); // waits 0
+      limiter.acquirePermit(); // waits 100
+      limiter.acquirePermit(); // waits 200
+    });
+    assertTrue(elapsed >= 300 && elapsed <= 400);
+  }
+
+  public void testAcquirePermitWithInterrupt() {
+    RateLimiterImpl<Object> limiter = new RateLimiterImpl<>(
+      RateLimiter.builder(Duration.ofMillis(1000)).build().getConfig(), stopwatch);
+
+    Thread thread = Thread.currentThread();
+    runInThread(() -> {
+      Thread.sleep(100);
+      thread.interrupt();
+    });
+    long elapsed = timed(() -> assertThrows(() -> {
+      limiter.acquirePermit(); // waits 0
+      limiter.acquirePermit(); // waits 1000
+    }, InterruptedException.class));
+    assertTrue(elapsed < 1000);
+  }
+
+  public void testAcquireWithTimeout() throws Throwable {
+    RateLimiterImpl<Object> limiter = new RateLimiterImpl<>(
+      RateLimiter.builder(Duration.ofMillis(100)).build().getConfig(), stopwatch);
+
+    limiter.acquirePermit(Duration.ofMillis(100)); // waits 0
+    limiter.acquirePermit(Duration.ofMillis(1000)); // waits 100
+    assertThrows(() -> {
+      limiter.acquirePermit(Duration.ofMillis(100)); // waits 200
+    }, RateLimitExceededException.class);
+  }
+
+  public void testTryAcquirePermit() {
+    RateLimiterImpl<Object> limiter = new RateLimiterImpl<>(
+      RateLimiter.builder(Duration.ofMillis(100)).build().getConfig(), stopwatch);
+
+    assertTrue(limiter.tryAcquirePermit());
+    assertFalse(limiter.tryAcquirePermit());
+
+    stopwatch.set(150);
+    assertTrue(limiter.tryAcquirePermit());
+    assertFalse(limiter.tryAcquirePermit());
+
+    stopwatch.set(210);
+    assertTrue(limiter.tryAcquirePermit());
+    assertFalse(limiter.tryAcquirePermit());
+  }
+
+  public void testTryAcquirePermitWithTimeout() throws Throwable {
+    RateLimiterImpl<Object> limiter = new RateLimiterImpl<>(
+      RateLimiter.builder(Duration.ofMillis(100)).build().getConfig(), stopwatch);
+
+    assertTrue(limiter.tryAcquirePermit(Duration.ofMillis(50)));
+    assertFalse(limiter.tryAcquirePermit(Duration.ofMillis(50)));
+    long elapsed = timed(() -> assertTrue(limiter.tryAcquirePermit(Duration.ofMillis(100))));
+    assertTrue(elapsed >= 100 && elapsed < 200);
+
+    stopwatch.set(200);
+    assertTrue(limiter.tryAcquirePermit(Duration.ofMillis(50)));
+    assertFalse(limiter.tryAcquirePermit(Duration.ofMillis(50)));
+    elapsed = timed(() -> assertTrue(limiter.tryAcquirePermit(Duration.ofMillis(100))));
+    assertTrue(elapsed >= 100 && elapsed < 200);
+  }
+
+  public void testTryAcquirePermitsWithTimeout() throws Throwable {
+    RateLimiterImpl<Object> limiter = new RateLimiterImpl<>(
+      RateLimiter.builder(Duration.ofMillis(100)).build().getConfig(), stopwatch);
+
+    assertFalse(limiter.tryAcquirePermits(2, Duration.ofMillis(50)));
+    long elapsed = timed(() -> assertTrue(limiter.tryAcquirePermits(2, Duration.ofMillis(100))));
+    assertTrue(elapsed >= 100 && elapsed < 200);
+
+    stopwatch.set(450);
+    assertFalse(limiter.tryAcquirePermits(2, Duration.ofMillis(10)));
+    elapsed = timed(() -> assertTrue(limiter.tryAcquirePermits(2, Duration.ofMillis(300))));
+    assertTrue(elapsed >= 50 && elapsed < 150);
+  }
+}

--- a/src/test/java/dev/failsafe/internal/RateLimiterImplTest.java
+++ b/src/test/java/dev/failsafe/internal/RateLimiterImplTest.java
@@ -29,8 +29,8 @@ import static org.testng.Assert.assertTrue;
 
 @Test
 public class RateLimiterImplTest extends Testing {
-  static RateLimiter<Object> smoothLimiter = RateLimiter.builder(Duration.ofMillis(500)).build();
-  static RateLimiter<Object> burstyLimiter = RateLimiter.builder(2, Duration.ofSeconds(1)).build();
+  static RateLimiter<Object> smoothLimiter = RateLimiter.smoothBuilder(Duration.ofMillis(500)).build();
+  static RateLimiter<Object> burstyLimiter = RateLimiter.burstyBuilder(2, Duration.ofSeconds(1)).build();
   TestStopwatch stopwatch;
 
   @BeforeMethod
@@ -50,7 +50,7 @@ public class RateLimiterImplTest extends Testing {
 
   public void testAcquirePermit() {
     RateLimiterImpl<Object> limiter = new RateLimiterImpl<>(
-      RateLimiter.builder(Duration.ofMillis(100)).build().getConfig(), stopwatch);
+      RateLimiter.smoothBuilder(Duration.ofMillis(100)).build().getConfig(), stopwatch);
 
     long elapsed = timed(() -> {
       limiter.acquirePermit(); // waits 0
@@ -62,7 +62,7 @@ public class RateLimiterImplTest extends Testing {
 
   public void testAcquirePermitWithInterrupt() {
     RateLimiterImpl<Object> limiter = new RateLimiterImpl<>(
-      RateLimiter.builder(Duration.ofMillis(1000)).build().getConfig(), stopwatch);
+      RateLimiter.smoothBuilder(Duration.ofMillis(1000)).build().getConfig(), stopwatch);
 
     Thread thread = Thread.currentThread();
     runInThread(() -> {
@@ -78,7 +78,7 @@ public class RateLimiterImplTest extends Testing {
 
   public void testAcquireWithMaxWaitTime() throws Throwable {
     RateLimiterImpl<Object> limiter = new RateLimiterImpl<>(
-      RateLimiter.builder(Duration.ofMillis(100)).build().getConfig(), stopwatch);
+      RateLimiter.smoothBuilder(Duration.ofMillis(100)).build().getConfig(), stopwatch);
 
     limiter.acquirePermit(Duration.ofMillis(100)); // waits 0
     limiter.acquirePermit(Duration.ofMillis(1000)); // waits 100
@@ -89,7 +89,7 @@ public class RateLimiterImplTest extends Testing {
 
   public void testTryAcquirePermit() {
     RateLimiterImpl<Object> limiter = new RateLimiterImpl<>(
-      RateLimiter.builder(Duration.ofMillis(100)).build().getConfig(), stopwatch);
+      RateLimiter.smoothBuilder(Duration.ofMillis(100)).build().getConfig(), stopwatch);
 
     assertTrue(limiter.tryAcquirePermit());
     assertFalse(limiter.tryAcquirePermit());
@@ -105,7 +105,7 @@ public class RateLimiterImplTest extends Testing {
 
   public void testTryAcquirePermitWithMaxWaitTime() throws Throwable {
     RateLimiterImpl<Object> limiter = new RateLimiterImpl<>(
-      RateLimiter.builder(Duration.ofMillis(100)).build().getConfig(), stopwatch);
+      RateLimiter.smoothBuilder(Duration.ofMillis(100)).build().getConfig(), stopwatch);
 
     assertTrue(limiter.tryAcquirePermit(Duration.ofMillis(50)));
     assertFalse(limiter.tryAcquirePermit(Duration.ofMillis(50)));
@@ -121,7 +121,7 @@ public class RateLimiterImplTest extends Testing {
 
   public void testTryAcquirePermitsWithMaxWaitTime() throws Throwable {
     RateLimiterImpl<Object> limiter = new RateLimiterImpl<>(
-      RateLimiter.builder(Duration.ofMillis(100)).build().getConfig(), stopwatch);
+      RateLimiter.smoothBuilder(Duration.ofMillis(100)).build().getConfig(), stopwatch);
 
     assertFalse(limiter.tryAcquirePermits(2, Duration.ofMillis(50)));
     long elapsed = timed(() -> assertTrue(limiter.tryAcquirePermits(2, Duration.ofMillis(100))));

--- a/src/test/java/dev/failsafe/internal/RateLimiterImplTest.java
+++ b/src/test/java/dev/failsafe/internal/RateLimiterImplTest.java
@@ -76,7 +76,7 @@ public class RateLimiterImplTest extends Testing {
     assertTrue(elapsed < 1000);
   }
 
-  public void testAcquireWithTimeout() throws Throwable {
+  public void testAcquireWithMaxWaitTime() throws Throwable {
     RateLimiterImpl<Object> limiter = new RateLimiterImpl<>(
       RateLimiter.builder(Duration.ofMillis(100)).build().getConfig(), stopwatch);
 
@@ -103,7 +103,7 @@ public class RateLimiterImplTest extends Testing {
     assertFalse(limiter.tryAcquirePermit());
   }
 
-  public void testTryAcquirePermitWithTimeout() throws Throwable {
+  public void testTryAcquirePermitWithMaxWaitTime() throws Throwable {
     RateLimiterImpl<Object> limiter = new RateLimiterImpl<>(
       RateLimiter.builder(Duration.ofMillis(100)).build().getConfig(), stopwatch);
 
@@ -119,7 +119,7 @@ public class RateLimiterImplTest extends Testing {
     assertTrue(elapsed >= 100 && elapsed < 200);
   }
 
-  public void testTryAcquirePermitsWithTimeout() throws Throwable {
+  public void testTryAcquirePermitsWithMaxWaitTime() throws Throwable {
     RateLimiterImpl<Object> limiter = new RateLimiterImpl<>(
       RateLimiter.builder(Duration.ofMillis(100)).build().getConfig(), stopwatch);
 

--- a/src/test/java/dev/failsafe/internal/RateLimiterStatsTest.java
+++ b/src/test/java/dev/failsafe/internal/RateLimiterStatsTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package dev.failsafe.internal;
+
+import dev.failsafe.internal.RateLimiterStats.Stopwatch;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import static org.testng.Assert.assertEquals;
+
+@Test
+public abstract class RateLimiterStatsTest<T extends RateLimiterStats> {
+  TestStopwatch stopwatch;
+
+  public static class TestStopwatch extends Stopwatch {
+    long currentTimeMillis;
+
+    void set(long currentTimeMillis) {
+      this.currentTimeMillis = currentTimeMillis;
+    }
+
+    @Override
+    long elapsedNanos() {
+      return TimeUnit.MILLISECONDS.toNanos(currentTimeMillis);
+    }
+
+    @Override
+    void reset() {
+      currentTimeMillis = 0;
+    }
+  }
+
+  /**
+   * Creates a stats with some arbitrary configuration.
+   */
+  abstract T createStats();
+
+  @BeforeMethod
+  protected void beforeMethod() {
+    stopwatch = new TestStopwatch();
+  }
+
+  /**
+   * Asserts that a single acquirePermits call yields the same result as numerous individual acquirePermits calls.
+   */
+  public void shouldAcquirePermitsEqually() {
+    // Given
+    T stats1 = createStats();
+    T stats2 = createStats();
+
+    // When making initial calls
+    long singlsCallWaitMillis = acquire(stats1, 7);
+    long mulipleCallsWaitMillis = acquire(stats2, 1, 7);
+
+    // Then
+    assertEquals(singlsCallWaitMillis, mulipleCallsWaitMillis);
+
+    // Given
+    stopwatch.set(2700);
+
+    // When making additional calls
+    singlsCallWaitMillis = acquire(stats1, 5);
+    mulipleCallsWaitMillis = acquire(stats2, 1, 5);
+
+    // Then
+    assertEquals(singlsCallWaitMillis, mulipleCallsWaitMillis);
+  }
+
+  /**
+   * Asserts that acquire on a new stats object with a single permit has zero wait time.
+   */
+  public void shouldHaveZeroWaitTime() {
+    assertEquals(acquire(createStats(), 1), 0);
+  }
+
+  /**
+   * Acquires {@code permits}, prints out info, and returns the wait time converted to millis.
+   */
+  long acquire(T stats, long permits) {
+    return acquire(stats, permits, 1);
+  }
+
+  /**
+   * Acquires {@code permits} {@code numberOfCalls} times, prints out info, and returns the wait time converted to
+   * millis.
+   */
+  long acquire(T stats, long permits, int numberOfCalls) {
+    long lastResult = 0;
+    for (int i = 0; i < numberOfCalls; i++)
+      lastResult = stats.acquirePermits(permits, null);
+    lastResult = toMillis(lastResult);
+    printInfo(stats, lastResult);
+    return lastResult;
+  }
+
+  abstract void printInfo(T stats, long waitMillis);
+
+  static long toMillis(long nanos) {
+    return TimeUnit.NANOSECONDS.toMillis(nanos);
+  }
+}

--- a/src/test/java/dev/failsafe/internal/SmoothRateLimiterStatsTest.java
+++ b/src/test/java/dev/failsafe/internal/SmoothRateLimiterStatsTest.java
@@ -22,7 +22,6 @@ import org.testng.annotations.Test;
 import java.time.Duration;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 
 @Test
 public class SmoothRateLimiterStatsTest extends RateLimiterStatsTest<SmoothRateLimiterStats> {

--- a/src/test/java/dev/failsafe/internal/SmoothRateLimiterStatsTest.java
+++ b/src/test/java/dev/failsafe/internal/SmoothRateLimiterStatsTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package dev.failsafe.internal;
+
+import dev.failsafe.RateLimiter;
+import dev.failsafe.RateLimiterConfig;
+import org.testng.annotations.Test;
+
+import java.time.Duration;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+@Test
+public class SmoothRateLimiterStatsTest extends RateLimiterStatsTest<SmoothRateLimiterStats> {
+  @Override
+  SmoothRateLimiterStats createStats() {
+    RateLimiterConfig<Object> config = RateLimiter.builder(Duration.ofMillis(500)).build().getConfig();
+    return new SmoothRateLimiterStats(config, stopwatch);
+  }
+
+  SmoothRateLimiterStats createStats(Duration rate) {
+    RateLimiterConfig<Object> config = RateLimiter.builder(rate).build().getConfig();
+    return new SmoothRateLimiterStats(config, stopwatch);
+  }
+
+  /**
+   * Asserts that wait times and available permits are expected, over time, when calling acquirePermits.
+   */
+  public void testAcquirePermits() {
+    // Given 1 per mit every 500 millis
+    SmoothRateLimiterStats stats = createStats(Duration.ofMillis(500));
+
+    long waitMillis = acquire(stats, 1, 7);
+    assertResults(stats, waitMillis, 3000, 3500);
+
+    stopwatch.set(800);
+    waitMillis = acquire(stats, 3);
+    assertResults(stats, waitMillis, 3700, 5000);
+
+    stopwatch.set(2300);
+    waitMillis = acquire(stats, 1);
+    assertResults(stats, waitMillis, 2700, 5500);
+
+    stopwatch.set(3500);
+    waitMillis = acquire(stats, 3);
+    assertResults(stats, waitMillis, 3000, 7000);
+
+    stopwatch.set(9100);
+    waitMillis = acquire(stats, 3);
+    assertResults(stats, waitMillis, 900, 10500);
+
+    stopwatch.set(11000);
+    waitMillis = acquire(stats, 1);
+    assertResults(stats, waitMillis, 0, 11500);
+
+    // Given 1 permit every 200 millis
+    stopwatch = new TestStopwatch();
+    stats = createStats(Duration.ofMillis(200));
+
+    waitMillis = acquire(stats, 3);
+    assertResults(stats, waitMillis, 400, 600);
+
+    stopwatch.set(550);
+    waitMillis = acquire(stats, 2);
+    assertResults(stats, waitMillis, 250, 1000);
+
+    stopwatch.set(2210);
+    waitMillis = acquire(stats, 2);
+    assertResults(stats, waitMillis, 190, 2600);
+  }
+
+  public void testAcquireInitialStats() {
+    // Given 1 permit every 100 millis
+    SmoothRateLimiterStats stats = createStats(Duration.ofMillis(100));
+
+    assertEquals(toMillis(stats.acquirePermits(1, null)), 0);
+    assertEquals(toMillis(stats.acquirePermits(1, null)), 100);
+    stopwatch.set(100);
+    assertEquals(toMillis(stats.acquirePermits(1, null)), 100);
+    assertEquals(toMillis(stats.acquirePermits(1, null)), 200);
+
+    // Given 1 permit every 100 millis
+    stats = createStats(Duration.ofMillis(100));
+    stopwatch.set(0);
+    assertEquals(toMillis(stats.acquirePermits(1, null)), 0);
+    stopwatch.set(150);
+    assertEquals(toMillis(stats.acquirePermits(1, null)), 0);
+    stopwatch.set(250);
+    assertEquals(toMillis(stats.acquirePermits(2, null)), 50);
+  }
+
+  private static void assertResults(SmoothRateLimiterStats stats, long waitMillis, long expectedWaitMillis,
+    long expectedNextFreePermitMillis) {
+    assertEquals(waitMillis, expectedWaitMillis);
+    assertEquals(toMillis(stats.getNextFreePermitNanos()), expectedNextFreePermitMillis);
+
+    // Asserts that the nextFreePermitNanos makes sense relative to the elapsedNanos and waitMillis
+    long computedNextFreePermitMillis =
+      toMillis(stats.stopwatch.elapsedNanos()) + waitMillis + toMillis(stats.intervalNanos);
+    assertEquals(toMillis(stats.getNextFreePermitNanos()), computedNextFreePermitMillis);
+  }
+
+  @Override
+  void printInfo(SmoothRateLimiterStats stats, long waitMillis) {
+    System.out.printf("[%s] elapsedMillis: %4s, waitMillis: %s, nextFreePermitNanos: %s%n",
+      Thread.currentThread().getName(), stats.getElapsed().toMillis(), waitMillis,
+      toMillis(stats.getNextFreePermitNanos()));
+  }
+}

--- a/src/test/java/dev/failsafe/internal/SmoothRateLimiterStatsTest.java
+++ b/src/test/java/dev/failsafe/internal/SmoothRateLimiterStatsTest.java
@@ -27,12 +27,12 @@ import static org.testng.Assert.assertEquals;
 public class SmoothRateLimiterStatsTest extends RateLimiterStatsTest<SmoothRateLimiterStats> {
   @Override
   SmoothRateLimiterStats createStats() {
-    RateLimiterConfig<Object> config = RateLimiter.builder(Duration.ofMillis(500)).build().getConfig();
+    RateLimiterConfig<Object> config = RateLimiter.smoothBuilder(Duration.ofMillis(500)).build().getConfig();
     return new SmoothRateLimiterStats(config, stopwatch);
   }
 
   SmoothRateLimiterStats createStats(Duration rate) {
-    RateLimiterConfig<Object> config = RateLimiter.builder(rate).build().getConfig();
+    RateLimiterConfig<Object> config = RateLimiter.smoothBuilder(rate).build().getConfig();
     return new SmoothRateLimiterStats(config, stopwatch);
   }
 

--- a/src/test/java/dev/failsafe/internal/util/MathsTest.java
+++ b/src/test/java/dev/failsafe/internal/util/MathsTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package dev.failsafe.internal.util;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+@Test
+public class MathsTest {
+  public void testAdd() {
+    assertEquals(Maths.add(100000, 100000), 100000 * 2);
+    assertEquals(Maths.add(Long.MAX_VALUE - 1000, 1000000), Long.MAX_VALUE);
+  }
+
+  public void testRoundDown() {
+    assertEquals(Maths.roundDown(0, 20), 0);
+    assertEquals(Maths.roundDown(40, 20), 40);
+    assertEquals(Maths.roundDown(57, 20), 40);
+    assertEquals(Maths.roundDown(57, 15), 45);
+  }
+}

--- a/src/test/java/dev/failsafe/issues/Issue242Test.java
+++ b/src/test/java/dev/failsafe/issues/Issue242Test.java
@@ -2,6 +2,7 @@ package dev.failsafe.issues;
 
 import dev.failsafe.Failsafe;
 import dev.failsafe.RetryPolicy;
+import dev.failsafe.testing.Testing;
 import org.testng.annotations.Test;
 
 import java.time.Duration;
@@ -10,15 +11,15 @@ import static dev.failsafe.testing.Testing.withLogs;
 import static org.testng.Assert.assertTrue;
 
 @Test
-public class Issue242Test {
+public class Issue242Test extends Testing {
   public void shouldDelayOnExplicitRetry() throws Throwable {
     RetryPolicy<String> retryPolicy = withLogs(
       RetryPolicy.<String>builder().handleResult(null).withDelay(Duration.ofMillis(110))).build();
 
-    long startTime = System.currentTimeMillis();
-    Failsafe.with(retryPolicy).runAsyncExecution(exec -> {
+    long elapsed = timed(() -> Failsafe.with(retryPolicy).runAsyncExecution(exec -> {
       exec.record(null, null);
-    }).get();
-    assertTrue(System.currentTimeMillis() - startTime > 200, "Expected delay between retries");
+    }).get());
+
+    assertTrue(elapsed > 200, "Expected delay between retries");
   }
 }

--- a/src/test/java/dev/failsafe/testing/Asserts.java
+++ b/src/test/java/dev/failsafe/testing/Asserts.java
@@ -17,18 +17,15 @@ package dev.failsafe.testing;
 
 import dev.failsafe.function.CheckedRunnable;
 import dev.failsafe.function.CheckedSupplier;
-import dev.failsafe.testing.Asserts.CompositeError;
-import io.vertx.core.eventbus.Message;
 import org.testng.Assert;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Formatter;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.function.Consumer;
+import java.util.function.Function;
 
 import static org.testng.Assert.assertEquals;
 
@@ -157,34 +154,26 @@ public class Asserts {
   }
 
   @SafeVarargs
-  public static void assertThrows(CheckedRunnable runnable, Class<? extends Throwable>... throwableHierarchy) {
-    assertThrows(runnable, t -> {
-    }, Arrays.asList(throwableHierarchy));
+  public static void assertThrows(CheckedRunnable runnable, Class<? extends Throwable>... expectedExceptions) {
+    assertThrows(runnable, t -> Arrays.asList(expectedExceptions));
   }
 
-  public static void assertThrows(CheckedRunnable runnable, List<Class<? extends Throwable>> throwableHierarchy) {
-    assertThrows(runnable, t -> {
-    }, throwableHierarchy);
-  }
-
-  public static void assertThrows(CheckedRunnable runnable, Consumer<Throwable> exceptionConsumer,
-    List<Class<? extends Throwable>> throwableHierarchy) {
-    boolean fail = false;
-    try {
-      runnable.run();
-      fail = true;
-    } catch (Throwable t) {
-      assertMatches(t, throwableHierarchy);
-      exceptionConsumer.accept(t);
-    }
-
-    if (fail)
-      Assert.fail("No exception was thrown. Expected: " + throwableHierarchy);
+  public static void assertThrows(CheckedRunnable runnable, List<Class<? extends Throwable>> expectedExceptions) {
+    assertThrows(runnable, t -> expectedExceptions);
   }
 
   public static <T> void assertThrowsSup(CheckedSupplier<T> supplier,
-    List<Class<? extends Throwable>> throwableHierarchy) {
-    assertThrows(supplier::get, t -> {
-    }, throwableHierarchy);
+    List<Class<? extends Throwable>> expectedExceptions) {
+    assertThrows(supplier::get, t -> expectedExceptions);
+  }
+
+  public static void assertThrows(CheckedRunnable runnable,
+    Function<Throwable, List<Class<? extends Throwable>>> expectedExceptionsFn) {
+    try {
+      runnable.run();
+      Assert.fail("No exception was thrown. Expected: " + expectedExceptionsFn.apply(null));
+    } catch (Throwable t) {
+      assertMatches(t, expectedExceptionsFn.apply(t));
+    }
   }
 }


### PR DESCRIPTION
A rate limiter with smooth and bursty variants, where the policy makes you choose one or the other. Has an optional timeout (for waiting on permits). The rate limiter can be used in a standalone way or as part of a Failsafe execution. 

See:
- RateLimiter.java for the policy interface
- RateLimiterExecutor.java for how the policy is used as part of a Failsafe execution

Since this impl doesn't include a warmup period, I'll open a separate issue for that to add later.

Closes #308 