### PR TITLE
Fix violations of Sonar rule 2142

### DIFF
--- a/src/test/java/dev/failsafe/functional/InterruptionTest.java
+++ b/src/test/java/dev/failsafe/functional/InterruptionTest.java
@@ -41,6 +41,7 @@ public class InterruptionTest extends Testing {
         Thread.sleep(100);
         main.interrupt();
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
       }
     });
 
@@ -68,6 +69,7 @@ public class InterruptionTest extends Testing {
         Thread.sleep(100);
         main.interrupt();
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
       }
     });
 
@@ -116,6 +118,7 @@ public class InterruptionTest extends Testing {
         Thread.sleep(100);
         t.interrupt();
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
       }
     }).start();
 

--- a/src/test/java/dev/failsafe/testing/Testing.java
+++ b/src/test/java/dev/failsafe/testing/Testing.java
@@ -125,6 +125,7 @@ public class Testing extends Logging {
     try {
       Thread.sleep(duration);
     } catch (InterruptedException ignore) {
+          Thread.currentThread().interrupt();
     }
   }
 


### PR DESCRIPTION
Hi,

This PR fixes 1 violations of [Sonar Rule 2142: '"InterruptedException" should not be ignored'](https://rules.sonarsource.com/java/RSPEC-2142). This is done without introducing any new violations of Sonar rules.

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 2142](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#interruptedexception-should-not-be-ignored-sonar-rule-2142).

P.S.: Note that this PR is not created/submitted by a bot. If you have any feedback, please leave them as comments.