### PR TITLE
Fix violations of Sonar rule 2095

### DIFF
--- a/src/test/java/dev/failsafe/testing/Asserts.java
+++ b/src/test/java/dev/failsafe/testing/Asserts.java
@@ -45,21 +45,20 @@ public class Asserts {
 
     @Override
     public String getMessage() {
-      Formatter fmt = new Formatter().format("Errors encountered:%n%n");
-      int index = 1;
-      for (Error error : errors) {
-        StringWriter writer = new StringWriter();
-        error.printStackTrace(new PrintWriter(writer));
-        fmt.format("%s) %s%n", index++, writer.getBuffer());
+      try (Formatter fmt = new Formatter().format("Errors encountered:%n%n")) {
+        int index = 1;
+        for (Error error : errors) {
+          StringWriter writer = new StringWriter();
+          error.printStackTrace(new PrintWriter(writer));
+          fmt.format("%s) %s%n", index++, writer.getBuffer());
+        }
+        if (errors.size() == 1) {
+          fmt.format("1 error");
+        } else {
+          fmt.format("%s errors", errors.size());
+        }
+        return fmt.toString();
       }
-
-      if (errors.size() == 1) {
-        fmt.format("1 error");
-      } else {
-        fmt.format("%s errors", errors.size());
-      }
-
-      return fmt.toString();
     }
   }
 


### PR DESCRIPTION
Hi,

This PR fixes 1 violations of [Sonar Rule 2095: 'Resources should be closed'](https://rules.sonarsource.com/java/RSPEC-2095). This is done without introducing any new violations of Sonar rules.

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 2095](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#resources-should-be-closed-sonar-rule-2095).

P.S.: Note that this PR is not created/submitted by a bot. If you have any feedback, please leave them as comments.