### PR TITLE
Introduced RetryPolicyBuilder.withBackoffResetAfter

### DIFF
--- a/core/src/main/java/dev/failsafe/RetryPolicyBuilder.java
+++ b/core/src/main/java/dev/failsafe/RetryPolicyBuilder.java
@@ -314,6 +314,16 @@ public class RetryPolicyBuilder<R> extends DelayablePolicyBuilder<RetryPolicyBui
   }
 
   /**
+   * If a backoff delay factor is given, the delay will be reset to the initial delay when a task attempt has been
+   * running without error for the given duration. This can be used for long-running tasks that can continue their work
+   * after a period with network issues for example.
+   */
+  public RetryPolicyBuilder<R> withBackoffResetAfter(Duration backoffReset) {
+    config.backoffReset = backoffReset;
+    return this;
+  }
+
+  /**
    * Sets the {@code delay} to occur between retries. Replaces any previously configured {@link #withBackoff(Duration,
    * Duration) backoff} or {@link #withDelay(Duration, Duration) random} delays.
    *

--- a/core/src/main/java/dev/failsafe/RetryPolicyConfig.java
+++ b/core/src/main/java/dev/failsafe/RetryPolicyConfig.java
@@ -41,6 +41,7 @@ public class RetryPolicyConfig<R> extends DelayablePolicyConfig<R> {
   Duration delayMin;
   Duration delayMax;
   double delayFactor;
+  Duration backoffReset;
   Duration maxDelay;
   Duration jitter;
   double jitterFactor;
@@ -63,6 +64,7 @@ public class RetryPolicyConfig<R> extends DelayablePolicyConfig<R> {
     delayMin = config.delayMin;
     delayMax = config.delayMax;
     delayFactor = config.delayFactor;
+    backoffReset = config.backoffReset;
     maxDelay = config.maxDelay;
     jitter = config.jitter;
     jitterFactor = config.jitterFactor;
@@ -144,6 +146,15 @@ public class RetryPolicyConfig<R> extends DelayablePolicyConfig<R> {
    */
   public double getDelayFactor() {
     return delayFactor;
+  }
+
+  /**
+   * Returns the duration after which the backoff delay will be reset
+   *
+   * @see RetryPolicyBuilder#withBackoffResetAfter(Duration)
+   */
+  public Duration getBackoffReset() {
+    return backoffReset;
   }
 
   /**

--- a/core/src/main/java/dev/failsafe/internal/RetryPolicyExecutor.java
+++ b/core/src/main/java/dev/failsafe/internal/RetryPolicyExecutor.java
@@ -279,6 +279,9 @@ public class RetryPolicyExecutor<R> extends PolicyExecutor<R> {
   }
 
   private long adjustForBackoff(ExecutionContext<R> context, long delayNanos) {
+    if (config.getBackoffReset() != null && context.getElapsedAttemptTime().compareTo(config.getBackoffReset()) >= 0) {
+      return config.getDelay().toNanos();
+    }
     if (context.getAttemptCount() != 1 && config.getMaxDelay() != null)
       delayNanos = (long) Math.min(delayNanos * config.getDelayFactor(), config.getMaxDelay().toNanos());
     return delayNanos;


### PR DESCRIPTION
Added option to reset the backoff delay to the initial delay when a (potentially long-running) task has been running without issues for a given duration.