### PR TITLE
Configure explicit Java module descriptors

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -11,11 +11,18 @@
   <artifactId>failsafe</artifactId>
   <name>Failsafe</name>
 
+  <properties>
+    <java.module.name>${project.groupId}.core</java.module.name>
+  </properties>
+
   <build>
     <plugins>
       <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.1.1</version>
         <executions>
           <execution>
             <goals>

--- a/modules/okhttp/pom.xml
+++ b/modules/okhttp/pom.xml
@@ -12,6 +12,10 @@
   <artifactId>failsafe-okhttp</artifactId>
   <name>Failsafe OkHttp</name>
 
+  <properties>
+    <java.module.name>${project.groupId}.okhttp</java.module.name>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -39,4 +43,13 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/modules/retrofit/pom.xml
+++ b/modules/retrofit/pom.xml
@@ -12,6 +12,10 @@
   <artifactId>failsafe-retrofit</artifactId>
   <name>Failsafe Retrofit</name>
 
+  <properties>
+    <java.module.name>${project.groupId}.retrofit</java.module.name>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -51,4 +55,13 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.moditect</groupId>
+        <artifactId>moditect-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,12 @@
     <tag>HEAD</tag>
   </scm>
 
+  <properties>
+    <java.module.name>undefined</java.module.name>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
   <modules>
     <module>core</module>
     <module>modules/okhttp</module>
@@ -61,20 +67,59 @@
   </dependencies>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.10.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.22.2</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.1.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.moditect</groupId>
+          <artifactId>moditect-maven-plugin</artifactId>
+          <version>1.0.0.RC2</version>
+          <executions>
+            <execution>
+              <id>add-module-infos</id>
+              <phase>package</phase>
+              <goals>
+                <goal>add-module-info</goal>
+              </goals>
+              <configuration>
+                <jvmVersion>9</jvmVersion>
+                <overwriteExistingFiles>true</overwriteExistingFiles>
+                <module>
+                  <moduleInfo>
+                    <name>${java.module.name}</name>
+                    <!-- export everything -->
+                    <exports>*;</exports>
+                    <!-- declare services consumed by the artifact -->
+                    <addServiceUses>true</addServiceUses>
+                  </moduleInfo>
+                </module>
+                <jdepsExtraArgs>
+                  <arg>--multi-release=9</arg>
+                </jdepsExtraArgs>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
         <configuration>
           <trimStackTrace>false</trimStackTrace>
           <properties>
@@ -95,7 +140,6 @@
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.1.1</version>
         <configuration>
           <archive>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>


### PR DESCRIPTION
Use the ModiTect plugin to add module descriptors while retaining Java 8 compatibility.

Fix for #358

**NOTE:** The release must be run with Java9+ or else it will fail to generate module descriptors. The CI workflow runs tests with `8`, `11`, and `17` which is fine as long as the `package` phase is not invoked.